### PR TITLE
Update effectStylesToTokens.ts

### DIFF
--- a/src/utils/styles/effectStylesToTokens.ts
+++ b/src/utils/styles/effectStylesToTokens.ts
@@ -16,36 +16,35 @@ export const effectStylesToTokens = async (
 
   const allEffectStyles = effectStyles.reduce((result, style) => {
     const styleName = style.name;
-    const effect = style.effects[0];
-
-    if (effect.type === "DROP_SHADOW" || effect.type === "INNER_SHADOW") {
-      const styleObject = {
-        [keyNames.type]: "shadow",
-        [keyNames.value]: {
-          inset: effect.type === "INNER_SHADOW",
-          color: convertRGBA(effect.color, colorMode),
-          offsetX: `${effect.offset.x}px`,
-          offsetY: `${effect.offset.y}px`,
-          blur: `${effect.radius}px`,
-          spread: `${effect.spread}px`,
-        },
-      } as unknown as ShadowTokenI;
-
-      result[styleName] = styleObject;
-    }
-
-    if (effect.type === "LAYER_BLUR" || effect.type === "BACKGROUND_BLUR") {
-      const styleObject = {
-        $type: "blur",
-        $value: {
-          role: effect.type === "LAYER_BLUR" ? "layer" : "background",
-          blur: `${effect.radius}px`,
-        },
-      } as BlurTokenI;
-
-      result[styleName] = styleObject;
-    }
-
+    
+    style.effects.forEach(effect => {
+        if (effect.type === "DROP_SHADOW" || effect.type === "INNER_SHADOW") {
+          result[styleName] = result[styleName] ?? [];
+          const styleObject = {
+            [keyNames.type]: "shadow",
+            [keyNames.value]: {
+              inset: effect.type === "INNER_SHADOW",
+              color: convertRGBA(effect.color, colorMode),
+              offsetX: `${effect.offset.x}px`,
+              offsetY: `${effect.offset.y}px`,
+              blur: `${effect.radius}px`,
+              spread: `${effect.spread}px`,
+            },
+          } as unknown as ShadowTokenI;
+          result[styleName].push(styleObject);
+        }
+      
+        if (effect.type === "LAYER_BLUR" || effect.type === "BACKGROUND_BLUR") {
+          const styleObject = {
+            $type: "blur",
+            $value: {
+              role: effect.type === "LAYER_BLUR" ? "layer" : "background",
+              blur: `${effect.radius}px`,
+            },
+          } as BlurTokenI;
+          result[styleName] = styleObject;
+        }
+    });
     return result;
   }, {});
 

--- a/src/utils/styles/effectStylesToTokens.ts
+++ b/src/utils/styles/effectStylesToTokens.ts
@@ -2,6 +2,20 @@ import { groupObjectNamesIntoCategories } from "../groupObjectNamesIntoCategorie
 import { convertRGBA } from "../color/convertRGBA";
 import { getTokenKeyName } from "../getTokenKeyName";
 
+const wrapShadowObject = (
+  shadowEffect: DropShadowEffect | InnerShadowEffect,
+  colorMode: colorModeType
+) => {
+  return {
+    inset: shadowEffect.type === "INNER_SHADOW",
+    color: convertRGBA(shadowEffect.color, colorMode),
+    offsetX: `${shadowEffect.offset.x}px`,
+    offsetY: `${shadowEffect.offset.y}px`,
+    blur: `${shadowEffect.radius}px`,
+    spread: `${shadowEffect.spread}px`,
+  };
+};
+
 export const effectStylesToTokens = async (
   customName: string,
   colorMode: colorModeType,
@@ -16,35 +30,38 @@ export const effectStylesToTokens = async (
 
   const allEffectStyles = effectStyles.reduce((result, style) => {
     const styleName = style.name;
-    
-    style.effects.forEach(effect => {
-        if (effect.type === "DROP_SHADOW" || effect.type === "INNER_SHADOW") {
-          result[styleName] = result[styleName] ?? [];
-          const styleObject = {
-            [keyNames.type]: "shadow",
-            [keyNames.value]: {
-              inset: effect.type === "INNER_SHADOW",
-              color: convertRGBA(effect.color, colorMode),
-              offsetX: `${effect.offset.x}px`,
-              offsetY: `${effect.offset.y}px`,
-              blur: `${effect.radius}px`,
-              spread: `${effect.spread}px`,
-            },
-          } as unknown as ShadowTokenI;
-          result[styleName].push(styleObject);
-        }
-      
-        if (effect.type === "LAYER_BLUR" || effect.type === "BACKGROUND_BLUR") {
-          const styleObject = {
-            $type: "blur",
-            $value: {
-              role: effect.type === "LAYER_BLUR" ? "layer" : "background",
-              blur: `${effect.radius}px`,
-            },
-          } as BlurTokenI;
-          result[styleName] = styleObject;
-        }
-    });
+    const effectType = style.effects[0].type;
+
+    console.log(styleName, style.effects);
+
+    if (effectType === "DROP_SHADOW" || effectType === "INNER_SHADOW") {
+      const styleObject = {
+        [keyNames.type]: "shadow",
+        [keyNames.value]:
+          style.effects.length === 1
+            ? wrapShadowObject(style.effects[0], colorMode)
+            : style.effects.map((effect) =>
+                wrapShadowObject(
+                  effect as DropShadowEffect | InnerShadowEffect,
+                  colorMode
+                )
+              ),
+      } as unknown as ShadowTokenI;
+      result[styleName] = styleObject;
+    }
+
+    if (effectType === "LAYER_BLUR" || effectType === "BACKGROUND_BLUR") {
+      const effect = style.effects[0];
+      const styleObject = {
+        $type: "blur",
+        $value: {
+          role: effectType === "LAYER_BLUR" ? "layer" : "background",
+          blur: `${effect.radius}px`,
+        },
+      } as BlurTokenI;
+      result[styleName] = styleObject;
+    }
+
     return result;
   }, {});
 


### PR DESCRIPTION
I haven't got any means to verify that my proposed changes work, but I feel like iterating over DROP_SHADOW or INNER_SHADOW effects is more suitable than picking the first occurrence of the effects array. Any shadow effect can have multiple individual shadows, instead of just one.

Please consider this as a suggestion. I would like to be able to include all of the shadow effect in the tokens file, rather than only the first occurrence. If you would like to dismiss this PR and create your own solution, or make changes to this PR, that would be fine by me. Just here to add my two cents. :)