### PR TITLE
Right the heuristic wrongs

### DIFF
--- a/src/utils/text/getFontWeight.ts
+++ b/src/utils/text/getFontWeight.ts
@@ -13,4 +13,4 @@ function getFontWeight(fontWeight){
     950 : ["extrablack", "ultrablack", "950"]
   }
   return Number(Object.keys(weights).find(weight => weights[weight].includes(inputFontWeight))) || 400;
-}
+};

--- a/src/utils/text/getFontWeight.ts
+++ b/src/utils/text/getFontWeight.ts
@@ -12,5 +12,5 @@ function getFontWeight(fontWeight){
     900 : ["black", "heavy", "900"],
     950 : ["extrablack", "ultrablack", "950"]
   }
-  return Object.keys(weights).find(weight => weights[weight].includes(inputFontWeight)) || 400;
+  return Number(Object.keys(weights).find(weight => weights[weight].includes(inputFontWeight))) || 400;
 }

--- a/src/utils/text/getFontWeight.ts
+++ b/src/utils/text/getFontWeight.ts
@@ -1,17 +1,16 @@
-export const getFontWeight = (fontWeight: string) => {
-  const inputFontWeight = fontWeight.toLowerCase();
-
+function getFontWeight(fontWeight){
+  const inputFontWeight = fontWeight.toLowerCase().replaceAll(/[-_.]/gi,"");  
   const weights = {
     100 : ["thin", "hairline", "100"],
-    200 : ["extra-light", "extraLight", "ultra-light", "ultraLight", "200"],
+    200 : ["extralight","ultralight", "200"],
     300 : ["light", "300"],
     400 : ["normal", "regular", "book", "400"],
     500 : ["medium", "500"],
-    600 : ["semi-bold", "semiBold", "demi-bold", "demiBold", "600"],
+    600 : ["semibold", "demibold", "600"],
     700 : ["bold", "700"],
-    800 : ["ultra-bold", "ultraBold", "extra-bold", "extraBold", "800"],
+    800 : ["ultrabold", "extrabold", "800"],
     900 : ["black", "heavy", "900"],
-    950 : ["extra-black", "ultra-black", "extraBlack", "ultraBlack", "950"]
+    950 : ["extrablack", "ultrablack", "950"]
   }
   return Object.keys(weights).find(weight => weights[weight].includes(inputFontWeight)) || 400;
-};
+}


### PR DESCRIPTION
Support naming conventions of any casing, and be indiscriminate on separators (currently supporting: "-", "_" and ".").

Please refer to my comment for the reasoning behind this PR (my apologies):
https://github.com/tokens-bruecke/figma-plugin/issues/18#issuecomment-1976424443