### PR TITLE
include variable's "codeSyntax" property in exported token json

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -108,6 +108,11 @@ interface PluginTokenI {
     mode: Object;
     figma: {
       variableId: string;
+      codeSyntax: {
+        WEB?: string;
+        iOS?: string;
+        ANDROID?: string;
+      };
       collection: {
         id: string;
         name: string;

--- a/src/utils/getTokensStat.ts
+++ b/src/utils/getTokensStat.ts
@@ -5,7 +5,6 @@ export const getTokensStat = (tokens) => {
   const codeLines = JSON.stringify(tokens, null, 2).split("\n").length;
 
   console.log("codeLines", codeLines);
-
   // get groups count
   const groupsCount = Object.keys(tokens).reduce((acc, key) => {
     const group = tokens[key];

--- a/src/utils/variablesToTokens.ts
+++ b/src/utils/variablesToTokens.ts
@@ -87,6 +87,7 @@ export const variablesToTokens = async (
       $extensions: {
         mode: filteredModesValues,
         figma: {
+          codeSyntax: variable.codeSyntax,
           variableId: variable.id,
           collection: collectionObject,
         },


### PR DESCRIPTION
My team found that while your plugin was a good fit for our use case, generating scss variables. Later however, we realized that depending on how our variables were organized (hierarchically) we could end up with Dev Mode showing us variable names like `var(--Brand-Midnight-Blue-Midnight-Blue-400)` that's obviously a little too verbose.

We found that we can assign the "[code syntax](https://help.figma.com/hc/en-us/articles/15145852043927-Create-and-manage-variables#code_syntax)" for a given variable which allowed us to customize the variable in the outputted css shown in Dev Mode. 

![image](https://github.com/user-attachments/assets/03b30622-8d59-4411-a285-28068b4a9d45)
Unfortunately, your plugin does not support "code syntax" at the moment. Since your project is open source, I thought I would make a quick PR. It's a really simple implementation but I'll allow us to make full use of your plugin. Thanks!

![image](https://github.com/user-attachments/assets/19bc0ce6-c561-4ce2-8558-5e2fdf66ef82)