### PR TITLE
Fixes dimension type for vars with single scope (issue #30)

### DIFF
--- a/src/utils/normilizeType.ts
+++ b/src/utils/normilizeType.ts
@@ -9,9 +9,8 @@ export const normilizeType = (type: VariableResolvedDataType, variableScopes: Va
         } else if (variableScopes[0] === "OPACITY") {
           return "number";
         }
-      } else {
-        return "dimension";
       }
+      return "dimension";
     case "STRING":
       return "string";
     case "BOOLEAN":


### PR DESCRIPTION
closes #30 

I've run the plugin locally and verified that this fix restores the `dimension` type on my exported number variables.