### PR TITLE
fix: cli package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,21 +7,21 @@
     "url": "https://pavellaptev.github.io"
   },
   "scripts": {
-    "build:cli": "tsc -p tsconfig.cli.json --outDir bin",
+    "build:cli": "webpack --mode=production --config webpack.config.cli.js",
     "build:plugin": "webpack --mode=production",
     "build": "npm run build:cli && npm run build:plugin",
     "dev": "webpack --mode=development --watch"
   },
-  "module": "true",
-  "main": "./bin/cli.js",
+  "type": "commonjs",
+  "main": "bin/cli.js",
   "bin": {
-    "tokens-bruecke": "./bin/cli.js"
+    "tokens-bruecke": "bin/cli.js"
   },
   "dependencies": {
     "@octokit/core": "^5.0.0",
     "clipboard-copy": "^4.0.1",
     "figma-api": "2.0.1-beta",
-    "pavelLaptev/react-figma-ui": "git+https://git@github.com/PavelLaptev/react-figma-ui#4c8d20dbd911c0008fd4d0b20280f14404f186e7",
+    "pavelLaptev/react-figma-ui": "git+https://git@github.com/PavelLaptev/react-figma-ui.git#4c8d20dbd911c0008fd4d0b20280f14404f186e7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "yargs": "^17.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: 2.0.1-beta
         version: 2.0.1-beta
       pavelLaptev/react-figma-ui:
-        specifier: git+https://git@github.com/PavelLaptev/react-figma-ui#4c8d20dbd911c0008fd4d0b20280f14404f186e7
+        specifier: git+https://git@github.com/PavelLaptev/react-figma-ui.git#4c8d20dbd911c0008fd4d0b20280f14404f186e7
         version: react-figma-ui@https://codeload.github.com/PavelLaptev/react-figma-ui/tar.gz/4c8d20dbd911c0008fd4d0b20280f14404f186e7
       react:
         specifier: ^18.2.0

--- a/webpack.config.cli.js
+++ b/webpack.config.cli.js
@@ -1,0 +1,36 @@
+const path = require("path");
+
+module.exports = {
+    mode: "production", // Use production mode for optimized output
+    target: "node", // Target Node.js environment
+    entry: "./src/cli.ts", // Entry point for the CLI
+    output: {
+        filename: "cli.js", // Output filename
+        path: path.resolve(__dirname, "bin"), // Output directory
+        libraryTarget: "commonjs2", // Use CommonJS module format
+    },
+    resolve: {
+        extensions: [".ts", ".js"], // Resolve TypeScript and JavaScript files
+    },
+
+    module: {
+        rules: [
+            {
+                test: /\.ts$/, // Process TypeScript files
+                use: {
+                    loader: "ts-loader",
+                    options: {
+                        configFile: "tsconfig.cli.json"
+                    }
+                },
+                exclude: /node_modules/,
+            },
+        ],
+    },
+    externals: {
+        // Exclude dependencies from the bundle
+        yargs: "commonjs yargs",
+        "react": "commonjs react",
+        "react-dom": "commonjs react-dom",
+    },
+};


### PR DESCRIPTION
Add webpack config for cli build.
It is necessary because tsc cannot transform extensionless imports to something nodejs accepts.