### PR TITLE
fix: fix warning about passing float to figma.ui.resize

### DIFF
--- a/src/app/controller/index.ts
+++ b/src/app/controller/index.ts
@@ -70,13 +70,13 @@ figma.ui.onmessage = async (msg) => {
 
   // change size of UI
   if (msg.type === "resizeUIHeight") {
-    figma.ui.resize(frameWidth, msg.height);
+    figma.ui.resize(frameWidth, Math.round(msg.height));
   }
 
   if (msg.type === "openCodePreview") {
     console.log("openCodePreview", msg.isCodePreviewOpen);
 
     isCodePreviewOpen = msg.isCodePreviewOpen;
-    figma.ui.resize(frameWidthWithCodePreview, msg.height);
+    figma.ui.resize(frameWidthWithCodePreview, Math.round(msg.height));
   }
 };

--- a/src/utils/changeUIFrameSize.ts
+++ b/src/utils/changeUIFrameSize.ts
@@ -1,7 +1,0 @@
-import { config } from "./config";
-
-export const changeUIFrameSize = (msg) => {
-  if (msg.type === "resizeUIHeight") {
-    figma.ui.resize(config.frameWidth, msg.height);
-  }
-};


### PR DESCRIPTION
There's a warning about passing floats to the figma.ui.resize method.

This PR fixes the warning.

https://github.com/user-attachments/assets/185ea5aa-e00b-40fb-845d-9c5dc39a24b3

