### PR TITLE
fix: handle font style value

### DIFF
--- a/src/common/transform/styles/textStylesToTokens.ts
+++ b/src/common/transform/styles/textStylesToTokens.ts
@@ -44,7 +44,7 @@ export const textStylesToTokens = async (
       [keyNames.value]: {
         fontFamily: aliasVariables.fontFamily || style.fontName.family,
         fontWeight: aliasVariables.fontWeight || fontStyleWeight.weight,
-        fontStyle: aliasVariables.fontStyle || fontStyleWeight.style,
+        fontStyle: fontStyleWeight.style || aliasVariables.fontStyle,
         fontSize: aliasVariables.fontSize || `${style.fontSize}px`,
         lineHeight:
           aliasVariables.lineHeight || getLineHeight(style.lineHeight),

--- a/src/common/transform/styles/textStylesToTokens.ts
+++ b/src/common/transform/styles/textStylesToTokens.ts
@@ -43,7 +43,7 @@ export const textStylesToTokens = async (
       [keyNames.type]: "typography",
       [keyNames.value]: {
         fontFamily: aliasVariables.fontFamily || style.fontName.family,
-        fontWeight: aliasVariables.fontWeight || fontStyleWeight.weight,
+        fontWeight: fontStyleWeight.weight || aliasVariables.fontWeight,
         fontStyle: fontStyleWeight.style || aliasVariables.fontStyle,
         fontSize: aliasVariables.fontSize || `${style.fontSize}px`,
         lineHeight:


### PR DESCRIPTION
With Typography styles, Figma handles font style and font weight as a combined property. Which is why it's processed [separately here.](https://github.com/tokens-bruecke/figma-plugin/blob/7b284d6239bb7f0bf7f9283667e38020ecd523db/src/common/transform/styles/textStylesToTokens.ts#L41)

In short, the typography style from figma will not have a fontStyle field. So this field must always be derived from the fontWeight field. Currently, it always sets the fontStyle to the fontWeight alias which could be something like "Bold Italic". The valid values for fontStyle are `normal`, `oblique` and `italic`.

This PR fixes this by always setting the fontWeight and fontStyle value after processing the fontWeight value.


NOTE:

This is what works for me. But please let me know if this affects something else.