### PR TITLE
Update styles default names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokens-bruecke",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/app/container.tsx
+++ b/src/app/container.tsx
@@ -31,15 +31,15 @@ const Container = () => {
       },
       text: {
         isIncluded: false,
-        customName: "Typography",
+        customName: "Typography-styles",
       },
       effects: {
         isIncluded: false,
-        customName: "Effects",
+        customName: "Effect-styles",
       },
       grids: {
         isIncluded: false,
-        customName: "Grids",
+        customName: "Grid-styles",
       },
     },
     variableCollections: [],

--- a/src/app/controller/getStorageConfig.ts
+++ b/src/app/controller/getStorageConfig.ts
@@ -7,6 +7,7 @@ export const getStorageConfig = async (key) => {
 
   const storageConfig = await figma.clientStorage.getAsync(storageVersionKey);
 
+
   // clear storage if storage version is different
   if (storageConfig && storageConfig !== actualStorageVersion) {
     figma.clientStorage.setAsync(key, null);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,15 +9,15 @@ const defaultConfig: ExportSettingsI = {
   includedStyles: {
     text: {
       isIncluded: false,
-      customName: "Typography",
+      customName: "Typography-styles",
     },
     effects: {
       isIncluded: false,
-      customName: "Effects",
+      customName: "Effect-styles",
     },
     grids: {
       isIncluded: false,
-      customName: "Grids",
+      customName: "Grid-styles",
     },
   },
   storeStyleInCollection: "none",


### PR DESCRIPTION
By default, there can be overlap between "style" tokens and variables, as both often use generic names like "Typography." This can lead to objects overriding each other during export. To prevent this, a "-styles" suffix has been added to style variable names.

<img width="324" alt="image" src="https://github.com/user-attachments/assets/2a8c2f4d-4f24-4d7c-963c-963fd85bfac0" />
