### PR TITLE
fix: URL encode file path for Gitlab API

### DIFF
--- a/src/app/api/servers/pushToGitlab.ts
+++ b/src/app/api/servers/pushToGitlab.ts
@@ -8,7 +8,8 @@ export const pushToGitlab = async (
   const glRepo = credentials.repo;
   const branch = credentials.branch;
   const glHost = credentials.host || 'gitlab.com';
-  const fileName = credentials.fileName;
+  // file name must be URL encoded to handle file paths correctly via Gitlab API
+  const fileName = encodeURIComponent(credentials.fileName);
   const commitMessage = credentials.commitMessage || 'Update tokens';
   const fileContent = JSON.stringify(tokens, null, 2);
 


### PR DESCRIPTION
## Description
This change will URL encoded the file name before fetching the Gitlab API to ensure that special characters like `/` can be used with the plugin.
[According to Gitlabs Documentation within the call file paths must be URL-encoded](https://docs.gitlab.com/api/rest/#namespaced-paths)

## Steps to Reproduce
1. You need to create a [project access token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html) with api scope.
2. In the plugin settings paste the token into the Project access token field.
3. Add an owner name, repository name and a branch name.
4. In the file name field specify a file path e.g. some/tokens/tokens.json. 
5. Press the "Save" button
6. Press "Push to Server" button
7. Check your Gitlab repo for a new commit