### PR TITLE
feat(servers): commit split token files to Github and Gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Is `off` by default. When enabled, each Figma variable collection is exported as
 
 - **Download JSON** — produces a `design.tokens.zip` archive containing one `{CollectionName}.tokens.json` per collection.
 - **CLI** — writes individual `{CollectionName}.tokens.json` files into the directory specified by `--output`.
+- **Push to a server** — the GitHub, GitHub PR and GitLab servers commit one `{CollectionName}.tokens.json` per collection in a single commit. The `File name` field of the server becomes the folder they are written into, e.g. `tokens` → `tokens/{CollectionName}.tokens.json`.
 
 This is useful when you want to keep component-level token files separate (e.g. `button.tokens.json`, `card.tokens.json`).
 
@@ -292,6 +293,7 @@ Is `off` by default. When enabled, each mode of a variable collection is exporte
 
 - **Download JSON** — produces a `design.tokens.zip` archive containing one `{CollectionName}/{ModeName}.tokens.json` per mode.
 - **CLI** — writes individual `{CollectionName}/{ModeName}.tokens.json` files into the directory specified by `--output`.
+- **Push to a server** — the GitHub, GitHub PR and GitLab servers commit one `{CollectionName}/{ModeName}.tokens.json` per mode in a single commit, inside the folder set in the server's `File name` field.
 
 Collections with a single mode are exported as a single `{CollectionName}.tokens.json` file.
 
@@ -670,6 +672,8 @@ In ordere to test if your credentials are valid you can make a test request by c
 4. In the file name field you can specify a path to the file. If the file doesn't exist, it will be created. If the file exists, it will be overwritten. File name should include the file extension, e.g. `tokens.json`.
 5. You can also specify a commit message.
 
+> **Splitting into several files.** If _Split collections into separate files_ or _Split modes into separate files_ is enabled in the advanced settings, the file name field is treated as a folder instead, and every file is written in a single commit — e.g. `tokens` → `tokens/Colors.tokens.json`, or `tokens/Colors/Light.tokens.json` when splitting by mode.
+
 ![fig.8](readme-assets/fig8.webp)
 
 ### [GitHub PR](https://github.com)
@@ -686,7 +690,10 @@ All the steps are the same as for the [GitHub](#github) server, except the last 
 1. You need to create a [project access token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html) with `api` scope.
 2. In the plugin settings paste the token into the `Project access token` field.
 3. Add an owner name, repository name and a branch name.
-4. In the file name field you can specify a path to the file. If the file doesn't exist, it will be created. If the file exists, it will be overwritten. File name should include the file extension, e.g. `tokens.json`. 5. You can also specify a commit message.
+4. In the file name field you can specify a path to the file. If the file doesn't exist, it will be created. If the file exists, it will be overwritten. File name should include the file extension, e.g. `tokens.json`.
+5. You can also specify a commit message.
+
+> **Splitting into several files.** If _Split collections into separate files_ or _Split modes into separate files_ is enabled in the advanced settings, the file name field is treated as a folder instead, and every file is written in a single commit — e.g. `tokens` → `tokens/Colors.tokens.json`, or `tokens/Colors/Light.tokens.json` when splitting by mode.
 
 ![fig.11](readme-assets/fig11.webp)
 

--- a/src/app/api/downloadTokensFile.ts
+++ b/src/app/api/downloadTokensFile.ts
@@ -2,6 +2,7 @@
 // https://stackoverflow.com/questions/19721439/download-json-object-as-a-file-from-browser
 
 import JSZip from 'jszip';
+import { splitTokensIntoFiles } from '../../common/transform/splitTokensIntoFiles';
 
 const triggerDownload = (blob: Blob, fileName: string) => {
   const url = URL.createObjectURL(blob);
@@ -19,48 +20,21 @@ export const downloadTokensFile = async (
   splitByCollection = false,
   splitByMode = false
 ) => {
-  if (splitByMode) {
-    // Keys are "CollectionName/ModeName" — write as {CollectionName}/{ModeName}.tokens.json
-    const zip = new JSZip();
-    for (const key of Object.keys(objectToSave)) {
-      const slashIndex = key.indexOf('/');
-      if (slashIndex !== -1) {
-        const collectionName = key.slice(0, slashIndex);
-        const modeName = key.slice(slashIndex + 1);
-        const safeCollection = collectionName.replace(/[/\\?%*:|"<>]/g, '-');
-        const safeMode = modeName.replace(/[/\\?%*:|"<>]/g, '-');
-        zip.file(
-          `${safeCollection}/${safeMode}.tokens.json`,
-          JSON.stringify({ [collectionName]: objectToSave[key] }, null, 2)
-        );
-      } else {
-        const safeFileName = key.replace(/[/\\?%*:|"<>]/g, '-');
-        zip.file(
-          `${safeFileName}.tokens.json`,
-          JSON.stringify({ [key]: objectToSave[key] }, null, 2)
-        );
-      }
-    }
-    const blob = await zip.generateAsync({ type: 'blob' });
-    triggerDownload(blob, 'design.tokens.zip');
-  } else if (splitByCollection) {
-    const zip = new JSZip();
-    for (const collectionName of Object.keys(objectToSave)) {
-      const safeFileName = collectionName.replace(/[/\\?%*:|"<>]/g, '-');
-      zip.file(
-        `${safeFileName}.tokens.json`,
-        JSON.stringify(
-          { [collectionName]: objectToSave[collectionName] },
-          null,
-          2
-        )
-      );
-    }
-    const blob = await zip.generateAsync({ type: 'blob' });
-    triggerDownload(blob, 'design.tokens.zip');
-  } else {
-    const json = JSON.stringify(objectToSave, null, 2);
-    const blob = new Blob([json], { type: 'application/json' });
-    triggerDownload(blob, 'design.tokens.json');
+  const files = splitTokensIntoFiles(objectToSave, {
+    splitByCollection,
+    splitByMode,
+  });
+
+  if (files.length === 1 && !splitByCollection && !splitByMode) {
+    const blob = new Blob([files[0].content], { type: 'application/json' });
+    triggerDownload(blob, files[0].path);
+    return;
   }
+
+  const zip = new JSZip();
+
+  files.forEach((file) => zip.file(file.path, file.content));
+
+  const blob = await zip.generateAsync({ type: 'blob' });
+  triggerDownload(blob, 'design.tokens.zip');
 };

--- a/src/app/api/servers/githubPullRequest.ts
+++ b/src/app/api/servers/githubPullRequest.ts
@@ -1,9 +1,14 @@
 import { Octokit } from '@octokit/core';
+import {
+  splitTokensIntoFiles,
+  SplitOptionsI,
+} from '../../../common/transform/splitTokensIntoFiles';
 
 export const githubPullRequest = async (
   credentials: GithubPullRequestCredentialsI,
   tokens: any,
-  toastCallback: (props: ToastIPropsI) => void
+  toastCallback: (props: ToastIPropsI) => void,
+  splitOptions: SplitOptionsI = {}
 ) => {
   const { token, owner, repo, baseBranch, fileName, pullRequestBody } =
     credentials;
@@ -11,7 +16,7 @@ export const githubPullRequest = async (
   const commitMessage = credentials.commitMessage || 'Update tokens';
   const pullRequestTitle =
     credentials.pullRequestTitle || 'chore(tokens): update tokens';
-  const fileContent = JSON.stringify(tokens, null, 2);
+  const files = splitTokensIntoFiles(tokens, splitOptions, fileName);
 
   const octokit = new Octokit({ auth: token });
 
@@ -23,6 +28,11 @@ export const githubPullRequest = async (
   async function create() {
     try {
       console.log('start creating pull request');
+
+      if (files.length === 0) {
+        throw new Error('There are no tokens to push');
+      }
+
       const commit = await createCommit();
       console.log('commit created');
       await createOrUpdateBranch(commit);
@@ -77,25 +87,23 @@ export const githubPullRequest = async (
       owner,
       repo,
       base_tree: baseRef.data.object.sha,
-      tree: [
-        {
-          path: fileName,
-          // mode 100644 is regular file
-          mode: '100644',
-          type: 'blob',
-          content: fileContent,
-        },
-      ],
+      tree: files.map((file) => ({
+        path: file.path,
+        // mode 100644 is regular file
+        mode: '100644' as const,
+        type: 'blob' as const,
+        content: file.content,
+      })),
     });
   }
 
   async function createOrUpdateBranch(commit: Commit) {
     if (await isBrunchExist(branch)) {
       console.log('update the branch');
-      updateBranch(commit);
+      await updateBranch(commit);
     } else {
       console.log('create a branch');
-      createBranch(commit);
+      await createBranch(commit);
     }
   }
 

--- a/src/app/api/servers/pushToGithub.ts
+++ b/src/app/api/servers/pushToGithub.ts
@@ -1,10 +1,14 @@
-import { Buffer } from 'buffer';
 import { Octokit } from '@octokit/core';
+import {
+  splitTokensIntoFiles,
+  SplitOptionsI,
+} from '../../../common/transform/splitTokensIntoFiles';
 
 export const pushToGithub = async (
   credentials: GithubCredentialsI,
   tokens: any,
-  toastCallback: (props: ToastIPropsI) => void
+  toastCallback: (props: ToastIPropsI) => void,
+  splitOptions: SplitOptionsI = {}
 ) => {
   const ghToken = credentials.token;
   const ghUser = credentials.owner;
@@ -12,90 +16,95 @@ export const pushToGithub = async (
   const branch = credentials.branch;
   const fileName = credentials.fileName;
   const commitMessage = credentials.commitMessage || 'Update tokens';
-  const fileContent = Buffer.from(JSON.stringify(tokens, null, 2)).toString(
-    'base64'
-  );
+  const files = splitTokensIntoFiles(tokens, splitOptions, fileName);
 
   const octokit = new Octokit({ auth: ghToken });
 
   const commonParams = {
     owner: ghUser,
     repo: ghRepo,
-    path: fileName,
   };
 
-  const commonPushParams = {
-    ...commonParams,
-    message: commitMessage,
-    content: fileContent,
-    branch: branch,
-  };
-
+  // The git data API is used instead of the contents API so that every file
+  // ends up in a single commit when the tokens are split into several files.
   try {
-    const { data: file } = await octokit.request(
-      'GET /repos/{owner}/{repo}/contents/{path}',
+    if (files.length === 0) {
+      throw new Error('There are no tokens to push');
+    }
+
+    const { data: ref } = await octokit.request(
+      'GET /repos/{owner}/{repo}/git/ref/{ref}',
       {
         ...commonParams,
-        ref: branch,
+        ref: `heads/${branch}`,
       }
     );
 
-    const response = await octokit.request(
-      'PUT /repos/{owner}/{repo}/contents/{path}',
+    const { data: baseCommit } = await octokit.request(
+      'GET /repos/{owner}/{repo}/git/commits/{commit_sha}',
       {
-        ...commonPushParams,
-        sha: file['sha'], // Use the existing sha when updating the file
+        ...commonParams,
+        commit_sha: ref.object.sha,
       }
     );
 
-    // handle status response
-    console.log('File updated successfully:', response);
+    const { data: tree } = await octokit.request(
+      'POST /repos/{owner}/{repo}/git/trees',
+      {
+        ...commonParams,
+        base_tree: baseCommit.tree.sha,
+        tree: files.map((file) => ({
+          path: file.path,
+          // mode 100644 is regular file
+          mode: '100644' as const,
+          type: 'blob' as const,
+          content: file.content,
+        })),
+      }
+    );
+
+    const { data: commit } = await octokit.request(
+      'POST /repos/{owner}/{repo}/git/commits',
+      {
+        ...commonParams,
+        message: commitMessage,
+        tree: tree.sha,
+        parents: [ref.object.sha],
+      }
+    );
+
+    await octokit.request('PATCH /repos/{owner}/{repo}/git/refs/{ref}', {
+      ...commonParams,
+      ref: `heads/${branch}`,
+      sha: commit.sha,
+    });
+
+    console.log('Files pushed successfully:', commit.sha);
     toastCallback({
       title: 'Github: Updated successfully',
-      message: 'Tokens on Github have been updated successfully',
+      message:
+        files.length > 1
+          ? `${files.length} token files on Github have been updated successfully`
+          : 'Tokens on Github have been updated successfully',
       options: {
         type: 'success',
       },
     });
   } catch (error) {
-    // handle status response
-    console.error('Error upating file:', error);
+    console.error('Error pushing files:', error);
 
-    if (error.status === 404) {
-      try {
-        const response = await octokit.request(
-          'PUT /repos/{owner}/{repo}/contents/{path}',
-          commonPushParams
-        );
-
-        // handle status response
-        console.log('File created successfully:', response);
-        toastCallback({
-          title: 'Github: Created successfully',
-          message: 'Tokens on Github have been created successfully',
-          options: {
-            type: 'success',
-          },
-        });
-      } catch (error) {
-        // handle status response
-        console.error('Error creating file:', error);
-        toastCallback({
-          title: 'Github: Error creating file',
-          message: `Error creating file: ${error.message}.`,
-          options: {
-            type: 'error',
-          },
-        });
-      }
-    } else {
-      toastCallback({
-        title: 'Github: An error occurred',
-        message: error.message,
-        options: {
-          type: 'error',
-        },
-      });
-    }
+    toastCallback({
+      title:
+        error.status === 404
+          ? 'Github: Not found'
+          : 'Github: An error occurred',
+      message:
+        error.status === 404
+          ? `Could not find "${branch}" in ${ghUser}/${ghRepo}. Check the repository name, the branch (it has to exist and have at least one commit) and the token scope.`
+          : error.message,
+      options: {
+        type: 'error',
+      },
+    });
   }
 };

--- a/src/app/api/servers/pushToGitlab.ts
+++ b/src/app/api/servers/pushToGitlab.ts
@@ -1,92 +1,147 @@
+import {
+  splitTokensIntoFiles,
+  SplitOptionsI,
+} from '../../../common/transform/splitTokensIntoFiles';
+
 export const pushToGitlab = async (
   credentials: GitlabCredentialsI,
   tokens: any,
-  toastCallback: (props: ToastIPropsI) => void
+  toastCallback: (props: ToastIPropsI) => void,
+  splitOptions: SplitOptionsI = {}
 ) => {
   const glToken = credentials.token;
   const glUser = credentials.owner;
   const glRepo = credentials.repo;
   const branch = credentials.branch;
   const glHost = credentials.host || 'gitlab.com';
-  // file name must be URL encoded to handle file paths correctly via Gitlab API
-  const fileName = encodeURIComponent(credentials.fileName);
   const commitMessage = credentials.commitMessage || 'Update tokens';
-  const fileContent = JSON.stringify(tokens, null, 2);
+  const files = splitTokensIntoFiles(
+    tokens,
+    splitOptions,
+    credentials.fileName
+  );
 
-  const payload = {
-    branch: branch,
-    commit_message: commitMessage,
-    content: fileContent,
+  const projectId = `${glUser}%2F${glRepo}`;
+  const baseUrl = `https://${glHost}/api/v4/projects/${projectId}`;
+  const headers = {
+    'Content-Type': 'application/json',
+    'PRIVATE-TOKEN': glToken,
   };
 
-  const fetchUrl = `https://${glHost}/api/v4/projects/${glUser}%2F${glRepo}/repository/files/${fileName}`;
-
-  const gitlabRequest = async (method: 'POST' | 'PUT') => {
-    try {
-      const response = await fetch(fetchUrl, {
-        method: method,
-        headers: {
-          'Content-Type': 'application/json',
-          'PRIVATE-TOKEN': glToken,
-        },
-        body: JSON.stringify(payload),
-      });
-
-      return await response.json();
-    } catch (error) {
-      console.error('Error:', error);
-      toastCallback({
-        title: 'Gitlab: An error occured',
-        message: `Error: ${error.message}`,
-        options: {
-          type: 'error',
-        },
-      });
-
-      return null;
-    }
-  };
-
-  const data = await gitlabRequest('POST');
-
-  console.log('Gitlab response', data);
-
-  if (data.message) {
-    if (data.message === 'A file with this name already exists') {
-      console.warn('File already exists, updating');
-
-      await gitlabRequest('PUT');
-
-      console.log('File updated successfully');
-      toastCallback({
-        title: 'Gitlab: Updated successfully',
-        message: 'Tokens on Gitlab have been updated successfully',
-        options: {
-          type: 'success',
-        },
-      });
-
-      return;
-    }
-
-    console.error('Error:', data.message);
+  const showError = (message: string) => {
+    console.error('Gitlab error:', message);
     toastCallback({
       title: 'Gitlab: An error occured',
-      message: `Error: ${data.message}`,
+      message: `Error: ${message}`,
       options: {
         type: 'error',
       },
     });
-  } else {
-    // handle status response
-    // if file doesn't exist, create it
-    console.log('File created successfully');
+  };
+
+  // Gitlab needs to know upfront whether a file is created or updated. A failed
+  // check is not conclusive, so those files are retried with the other action.
+  const fileExists = async (path: string): Promise<boolean | null> => {
+    try {
+      const response = await fetch(
+        `${baseUrl}/repository/files/${encodeURIComponent(
+          path
+        )}?ref=${encodeURIComponent(branch)}`,
+        { method: 'HEAD', headers }
+      );
+
+      if (response.ok) return true;
+      if (response.status === 404) return false;
+
+      return null;
+    } catch (error) {
+      console.warn('Could not check if the file exists', path, error);
+      return null;
+    }
+  };
+
+  const commitFiles = (actions: Record<string, string>[]) =>
+    fetch(`${baseUrl}/repository/commits`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        branch,
+        commit_message: commitMessage,
+        actions,
+      }),
+    });
+
+  const readResponse = async (response: Response) => {
+    const body = await response.text();
+
+    try {
+      return JSON.parse(body);
+    } catch {
+      return { message: body || `Request failed: ${response.status}` };
+    }
+  };
+
+  try {
+    if (files.length === 0) {
+      showError('There are no tokens to push');
+      return;
+    }
+
+    const checks = await Promise.all(
+      files.map(async (file) => ({
+        file,
+        exists: await fileExists(file.path),
+      }))
+    );
+
+    const toActions = (flipUnknown: boolean) =>
+      checks.map(({ file, exists }) => ({
+        action:
+          exists === null
+            ? flipUnknown
+              ? 'create'
+              : 'update'
+            : exists
+            ? 'update'
+            : 'create',
+        file_path: file.path,
+        content: file.content,
+      }));
+
+    // A single commit holds every file, even when the tokens are split
+    let response = await commitFiles(toActions(false));
+    let data = await readResponse(response);
+
+    const hasUncertainFiles = checks.some(({ exists }) => exists === null);
+    const isActionMismatch = /exists|does ?n[o']t exist/i.test(
+      data?.message || ''
+    );
+
+    if (!response.ok && hasUncertainFiles && isActionMismatch) {
+      console.warn('Retrying the commit with the other action', data.message);
+      response = await commitFiles(toActions(true));
+      data = await readResponse(response);
+    }
+
+    if (!response.ok) {
+      showError(
+        data?.message || data?.error || `Request failed: ${response.status}`
+      );
+      return;
+    }
+
+    console.log('Gitlab response', data);
     toastCallback({
-      title: 'Gitlab: Created successfully',
-      message: 'Tokens on Gitlab have been created successfully',
+      title: 'Gitlab: Updated successfully',
+      message:
+        files.length > 1
+          ? `${files.length} token files on Gitlab have been updated successfully`
+          : 'Tokens on Gitlab have been updated successfully',
       options: {
         type: 'success',
       },
     });
+  } catch (error) {
+    showError(error.message);
   }
 };

--- a/src/app/views/ServerSettingsView/index.tsx
+++ b/src/app/views/ServerSettingsView/index.tsx
@@ -334,6 +334,10 @@ export const ServerSettingsView = (props: ViewProps) => {
   const { JSONsettingsConfig, setJSONsettingsConfig, setCurrentView } = props;
   const [errorFields, setErrorFields] = useState([] as string[]);
 
+  // When the tokens are split, the file name field points at a folder instead
+  const isSplitEnabled =
+    JSONsettingsConfig.splitByCollection || JSONsettingsConfig.splitByMode;
+
   const [config, setConfig] = useState(
     viewsConfig[props.server].fields.reduce((acc, field) => {
       const serverSettings = (JSONsettingsConfig.servers[props.server] ||
@@ -404,11 +408,16 @@ export const ServerSettingsView = (props: ViewProps) => {
               });
             };
 
+            const placeholder =
+              field.id === 'fileName' && isSplitEnabled
+                ? 'Folder path (e.g. tokens)'
+                : field.placeholder;
+
             return (
               <Input
                 key={field.id}
                 id={field.id}
-                placeholder={field.placeholder}
+                placeholder={placeholder}
                 value={
                   JSONsettingsConfig.servers[props.server]?.[field.id] || ''
                 }

--- a/src/app/views/SettingsView/index.tsx
+++ b/src/app/views/SettingsView/index.tsx
@@ -304,6 +304,11 @@ export const SettingsView = (props: ViewProps) => {
         }
 
         if (role === 'push') {
+          const splitOptions = {
+            splitByCollection: JSONsettingsConfig.splitByCollection,
+            splitByMode: JSONsettingsConfig.splitByMode,
+          };
+
           if (server.includes('jsonbin')) {
             console.log('push to jsonbin');
             await pushToJSONBin(
@@ -323,7 +328,8 @@ export const SettingsView = (props: ViewProps) => {
               tokens,
               (params) => {
                 toastRef.current?.show(params);
-              }
+              },
+              splitOptions
             );
           }
 
@@ -334,7 +340,8 @@ export const SettingsView = (props: ViewProps) => {
               tokens,
               (params) => {
                 toastRef.current?.show(params);
-              }
+              },
+              splitOptions
             );
           }
 
@@ -345,7 +352,8 @@ export const SettingsView = (props: ViewProps) => {
               tokens,
               (params) => {
                 toastRef.current?.show(params);
-              }
+              },
+              splitOptions
             );
           }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,12 +2,13 @@
 
 import yargs from 'yargs';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join, dirname } from 'path';
+import { dirname } from 'path';
 import { RestAPIResolver } from './restApiResolver';
 import { FileResolver, parseSnapshot } from './fileResolver';
 import { runInit } from './init';
 import { DEFAULT_CONFIG_FILENAME, defaultConfig } from './defaults';
 import { getTokens } from '@common/export';
+import { splitTokensIntoFiles } from '@common/transform/splitTokensIntoFiles';
 import { log, setQuiet } from './logger';
 
 // Flags that only make sense when fetching from the REST API
@@ -305,48 +306,29 @@ async function exportFigmaTokens() {
   }
 
   try {
-    if (options.splitByMode) {
-      // Keys are "CollectionName/ModeName" — write as {output}/{CollectionName}/{ModeName}.tokens.json
-      for (const key of Object.keys(tokens)) {
-        const slashIndex = key.indexOf('/');
-        let filePath: string;
-        let fileContent: Record<string, any>;
-        if (slashIndex !== -1) {
-          const collectionName = key.slice(0, slashIndex);
-          const modeName = key.slice(slashIndex + 1);
-          const safeCollection = collectionName.replace(/[/\\?%*:|"<>]/g, '-');
-          const safeMode = modeName.replace(/[/\\?%*:|"<>]/g, '-');
-          filePath = join(
-            argv.output,
-            safeCollection,
-            `${safeMode}.tokens.json`
-          );
-          fileContent = { [collectionName]: tokens[key] };
-        } else {
-          const safeFileName = key.replace(/[/\\?%*:|"<>]/g, '-');
-          filePath = join(argv.output, `${safeFileName}.tokens.json`);
-          fileContent = { [key]: tokens[key] };
-        }
-        mkdirSync(dirname(filePath), { recursive: true });
-        writeFileSync(filePath, JSON.stringify(fileContent, null, 2), 'utf-8');
-        log('✨ Written', filePath);
-      }
-    } else if (options.splitByCollection) {
-      mkdirSync(argv.output, { recursive: true });
-      for (const collectionName of Object.keys(tokens)) {
-        const safeFileName = collectionName.replace(/[/\\?%*:|"<>]/g, '-');
-        const filePath = join(argv.output, `${safeFileName}.tokens.json`);
-        writeFileSync(
-          filePath,
-          JSON.stringify({ [collectionName]: tokens[collectionName] }, null, 2),
-          'utf-8'
-        );
-        log('✨ Written', filePath);
-      }
-    } else {
-      mkdirSync(dirname(argv.output), { recursive: true });
-      writeFileSync(argv.output, JSON.stringify(tokens, null, 2), 'utf-8');
+    const files = splitTokensIntoFiles(
+      tokens,
+      {
+        splitByCollection: options.splitByCollection,
+        splitByMode: options.splitByMode,
+        targetIsFolder: options.splitByCollection || options.splitByMode,
+      },
+      argv.output
+    );
+
+    for (const file of files) {
+      mkdirSync(dirname(file.path), { recursive: true });
+      writeFileSync(file.path, file.content, 'utf-8');
+    }
+
+    if (
+      files.length === 1 &&
+      !options.splitByCollection &&
+      !options.splitByMode
+    ) {
       log('✨ Tokens successfully written to', argv.output);
+    } else {
+      files.forEach((file) => log('✨ Written', file.path));
     }
   } catch (error) {
     console.error('🔴 Error writing to output file:', error);

--- a/src/common/transform/splitTokensIntoFiles.spec.ts
+++ b/src/common/transform/splitTokensIntoFiles.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import { splitTokensIntoFiles } from './splitTokensIntoFiles';
+
+const tokens = {
+  Colors: { red: { $value: '#f00' } },
+  Spacing: { sm: { $value: '4px' } },
+};
+
+const byMode = {
+  'Colors/Light': { red: { $value: '#f00' } },
+  'Colors/Dark': { red: { $value: '#900' } },
+};
+
+describe('splitTokensIntoFiles', () => {
+  it('returns a single file when nothing is split', () => {
+    const files = splitTokensIntoFiles(tokens, {}, 'tokens/design.tokens.json');
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe('tokens/design.tokens.json');
+    expect(JSON.parse(files[0].content)).toEqual(tokens);
+  });
+
+  it('falls back to a default name without a target', () => {
+    expect(splitTokensIntoFiles(tokens)[0].path).toBe('design.tokens.json');
+  });
+
+  it('writes one file per collection', () => {
+    const files = splitTokensIntoFiles(
+      tokens,
+      { splitByCollection: true },
+      'tokens'
+    );
+
+    expect(files.map((file) => file.path)).toEqual([
+      'tokens/Colors.tokens.json',
+      'tokens/Spacing.tokens.json',
+    ]);
+    expect(JSON.parse(files[0].content)).toEqual({ Colors: tokens.Colors });
+  });
+
+  it('writes one file per mode inside a collection folder', () => {
+    const files = splitTokensIntoFiles(byMode, { splitByMode: true }, 'tokens');
+
+    expect(files.map((file) => file.path)).toEqual([
+      'tokens/Colors/Light.tokens.json',
+      'tokens/Colors/Dark.tokens.json',
+    ]);
+    expect(JSON.parse(files[0].content)).toEqual({
+      Colors: byMode['Colors/Light'],
+    });
+  });
+
+  it('strips a saved file name when splitting', () => {
+    const files = splitTokensIntoFiles(
+      tokens,
+      { splitByCollection: true },
+      'tokens/design.tokens.json'
+    );
+
+    expect(files[0].path).toBe('tokens/Colors.tokens.json');
+  });
+
+  it('keeps a dotted folder name that is not a json file', () => {
+    const files = splitTokensIntoFiles(
+      tokens,
+      { splitByCollection: true },
+      'packages/tokens.v2'
+    );
+
+    expect(files[0].path).toBe('packages/tokens.v2/Colors.tokens.json');
+  });
+
+  it('makes repository paths relative', () => {
+    const files = splitTokensIntoFiles(
+      tokens,
+      { splitByCollection: true },
+      '/tokens/design.tokens.json'
+    );
+
+    expect(files[0].path).toBe('tokens/Colors.tokens.json');
+  });
+
+  it('keeps a dotted folder name when the target is a folder', () => {
+    const files = splitTokensIntoFiles(
+      tokens,
+      { splitByCollection: true, targetIsFolder: true },
+      './out.v2'
+    );
+
+    expect(files[0].path).toBe('./out.v2/Colors.tokens.json');
+  });
+
+  it('keeps absolute paths and sanitizes names', () => {
+    const files = splitTokensIntoFiles(
+      { 'Colors/Brand': { red: { $value: '#f00' } } },
+      { splitByCollection: true, targetIsFolder: true },
+      '/tmp/tokens/'
+    );
+
+    expect(files[0].path).toBe('/tmp/tokens/Colors-Brand.tokens.json');
+  });
+
+  it('handles keys without a mode when splitting by mode', () => {
+    const files = splitTokensIntoFiles(tokens, { splitByMode: true }, '');
+
+    expect(files.map((file) => file.path)).toEqual([
+      'Colors.tokens.json',
+      'Spacing.tokens.json',
+    ]);
+  });
+});

--- a/src/common/transform/splitTokensIntoFiles.ts
+++ b/src/common/transform/splitTokensIntoFiles.ts
@@ -1,0 +1,108 @@
+export interface TokenFileI {
+  path: string;
+  content: string;
+}
+
+export interface SplitOptionsI {
+  splitByCollection?: boolean;
+  splitByMode?: boolean;
+  // `target` is always a folder, so a name like `v1.2` is not mistaken for a file
+  targetIsFolder?: boolean;
+}
+
+const SINGLE_FILE_NAME = 'design.tokens.json';
+
+// Figma collection and mode names can contain characters that are illegal in
+// file paths, so they are replaced before being used as a file or folder name.
+const safeName = (name: string) => name.replace(/[/\\?%*:|"<>]/g, '-');
+
+// The leading slash of the first part is kept so absolute paths survive
+const joinPath = (...parts: string[]) =>
+  parts
+    .filter(Boolean)
+    .map((part, index) =>
+      index === 0 ? part.replace(/\/+$/g, '') : part.replace(/^\/+|\/+$/g, '')
+    )
+    .filter(Boolean)
+    .join('/');
+
+// When splitting, the target is a folder. Users coming from single file exports
+// may still have a `*.json` file path saved, so that file name is stripped off.
+// Any other name is kept as is, so a folder like `tokens.v2` survives.
+const toFolder = (target: string) => {
+  const trimmed = (target || '').replace(/\/+$/g, '');
+
+  if (!trimmed) return '';
+
+  const lastSegment = trimmed.slice(trimmed.lastIndexOf('/') + 1);
+
+  return /\.json$/i.test(lastSegment)
+    ? trimmed.slice(0, trimmed.length - lastSegment.length).replace(/\/+$/, '')
+    : trimmed;
+};
+
+/**
+ * Turns the generated tokens object into the list of files that should be
+ * written, downloaded or committed.
+ *
+ * - `target` is the file path when nothing is split
+ * - `target` is the folder path when `splitByCollection` or `splitByMode` is on
+ */
+export const splitTokensIntoFiles = (
+  tokens: Record<string, any>,
+  {
+    splitByCollection = false,
+    splitByMode = false,
+    targetIsFolder = false,
+  }: SplitOptionsI = {},
+  target = ''
+): TokenFileI[] => {
+  const stringify = (value: Record<string, any>) =>
+    JSON.stringify(value, null, 2);
+
+  if (!splitByCollection && !splitByMode) {
+    return [
+      {
+        path: target || SINGLE_FILE_NAME,
+        content: stringify(tokens),
+      },
+    ];
+  }
+
+  // Repository paths (the servers) are always relative, only the CLI writes
+  // to an absolute folder
+  const folder = targetIsFolder
+    ? target.replace(/\/+$/g, '')
+    : toFolder(target).replace(/^\/+/, '');
+
+  if (splitByMode) {
+    // Keys are "CollectionName/ModeName" — write as {CollectionName}/{ModeName}.tokens.json
+    return Object.keys(tokens).map((key) => {
+      const slashIndex = key.indexOf('/');
+
+      if (slashIndex === -1) {
+        return {
+          path: joinPath(folder, `${safeName(key)}.tokens.json`),
+          content: stringify({ [key]: tokens[key] }),
+        };
+      }
+
+      const collectionName = key.slice(0, slashIndex);
+      const modeName = key.slice(slashIndex + 1);
+
+      return {
+        path: joinPath(
+          folder,
+          safeName(collectionName),
+          `${safeName(modeName)}.tokens.json`
+        ),
+        content: stringify({ [collectionName]: tokens[key] }),
+      };
+    });
+  }
+
+  return Object.keys(tokens).map((collectionName) => ({
+    path: joinPath(folder, `${safeName(collectionName)}.tokens.json`),
+    content: stringify({ [collectionName]: tokens[collectionName] }),
+  }));
+};


### PR DESCRIPTION
The `Split collections into separate files` and `Split modes into separate files` settings only affected the JSON download and the CLI. Pushing to a git server always wrote a single merged file, so the settings silently did nothing there.

Now the Github, Github PR and Gitlab servers write one file per collection (or per mode), and all of them land in a **single commit**. When either split setting is enabled, the server's `File name` field is treated as the destination folder, e.g. `tokens` → `tokens/Colors.tokens.json`, or `tokens/Colors/Light.tokens.json` when splitting by mode. The field's placeholder changes to `Folder path` so this is visible in the UI.

### Changes

- New `splitTokensIntoFiles` helper holds the naming rules that were duplicated between the download and the CLI, and is now shared by every export path. Covered by 10 new tests.
- The Github push moved from the contents API to the git data API (blob/tree/commit/update-ref), so several files land in one commit instead of one commit per file. The Github PR adapter simply maps every file into the tree it already builds.
- The Gitlab push moved to the commits API with an `actions[]` array. Each path is probed to pick `create` vs `update`; when a probe is inconclusive the commit is retried once with the other action.
- README documents the new behaviour in both the advanced settings and the server setup sections.

### Not included

Pushes stay additive: renaming or deleting a collection in Figma leaves the previous `*.tokens.json` behind. Pruning needs a listing of the target folder first and can follow separately.