### PR TITLE
Motion token support (duration, cubicBezier easing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The plugin converts Figma variables into design-tokens JSON that are compatible 
     - [Add styles to](#add-styles-to)
     - [Include variable scopes](#include-variable-scopes)
     - [Use percentage for opacity](#use-percentage-for-opacity)
+    - [Expand easing presets to cubic-bezier](#expand-easing-presets-to-cubic-bezier)
     - [DTCG 2025.10 format](#dtcg-202510-format)
     - [Include `.value` string for aliases](#include-value-string-for-aliases)
     - [Include Figma metadata](#include-figma-metadata)
@@ -63,6 +64,7 @@ The plugin converts Figma variables into design-tokens JSON that are compatible 
     - [Handle variables from another file](#handle-variables-from-another-file)
     - [Handle modes](#handle-modes)
   - [Variables types conversion](#variables-types-conversion)
+  - [Motion variables](#motion-variables)
   - [Design tokens types](#design-tokens-types)
   - [Scopes lemitations](#scopes-lemitations)
   - [Feedback](#feedback)
@@ -100,13 +102,14 @@ The plugin supports both **exporting** and **importing** design tokens:
 
 - ✅ Creates variable collections from top-level objects
 - ✅ Supports multiple modes (from `$extensions.mode` or `extensions.mode`)
-- ✅ Handles all variable types (color, number, string, boolean)
+- ✅ Handles all variable types (color, number, string, boolean, timing, easing)
 - ✅ Resolves alias references between variables
 - ✅ Supports various color formats (HEX, RGBA CSS, RGBA Object)
 - ✅ Preserves variable descriptions and metadata
+- ✅ Imports `duration` and `cubicBezier` tokens as Figma motion variables (see [Motion variables](#motion-variables))
 
 > [!WARNING]  
-> **Styles Export Limitation**: If you exported tokens with styles included (typography, grids, shadows, or blur), these cannot be imported back as Figma styles or variables. Figma's variable API currently only supports basic types: `color`, `number`, `string`, `boolean`, and `dimension`. Complex style types will be imported as `STRING` variables without proper value conversion. This is a temporary limitation until Figma supports these types natively in their API.
+> **Styles Export Limitation**: If you exported tokens with styles included (typography, grids, shadows, or blur), these cannot be imported back as Figma styles or variables. Figma's variable API currently only supports basic types: `color`, `number`, `string`, `boolean`, `dimension`, `duration` and `cubicBezier`. Complex style types will be imported as `STRING` variables without proper value conversion. This is a temporary limitation until Figma supports these types natively in their API.
 
 ---
 
@@ -176,6 +179,34 @@ Is `off` by default. When enabled, opacity values will be exported as percentage
   }
 }
 ```
+
+### Expand easing presets to cubic-bezier
+
+Is `on` by default. Figma's `EASING` variables hold either a custom curve or one of Figma's named presets, and the API only returns numbers for the custom ones — a preset arrives as just its name.
+
+When enabled, the named bezier presets (Linear, Ease in, Ease out, Ease in and out and the three "back" variants) are expanded into their curve, so every bezier easing exports as a spec-valid `cubicBezier` token. When disabled, they keep the name Figma gave them.
+
+```json
+// Expanded (default)
+{
+  "easing": {
+    "$type": "cubicBezier",
+    "$value": [0.41, 0, 1, 1]
+  }
+}
+
+// Not expanded
+{
+  "easing": {
+    "$type": "string",
+    "$value": "ease-in"
+  }
+}
+```
+
+Custom beziers always export as `cubicBezier` and are unaffected by this setting.
+
+Spring presets (Gentle, Quick, Bouncy, Slow), custom springs and Hold are always exported as strings regardless of the setting — DTCG has no spring type, and Figma exposes no curve to expand a spring into. See [Motion variables](#motion-variables) for the full mapping.
 
 ### DTCG 2025.10 format
 
@@ -547,6 +578,7 @@ You can use a JSON configuration file to specify the export options for the CLI.
   "includeValueStringKeyToAlias": true,
   "includeFigmaMetaData": false, // Include Figma metadata like styleId, variableId, etc.
   "usePercentageOpacity": false, // Export opacity as percentage (10%) instead of decimal (0.1)
+  "expandEasingPresets": true, // Expand Figma's named easing presets into cubicBezier values
   "colorMode": "hex", // "hex"  | "rgba-object"  | "srgb-dtcg" |  "rgba-css"  | "hsla-object" | "hsl-dtcg" | "hsla-css" | "oklch-dtcg";
   "storeStyleInCollection": "none", // Name of one of your collection or "none" to keep them separated
   "splitByCollection": false, // Write each collection as a separate .tokens.json file
@@ -1042,7 +1074,7 @@ It follows the same pattern as used by [Cobalt](https://cobalt-ui.pages.dev/guid
 
 ## Variables types conversion
 
-Unlike design tokens, Figma variables now [support only 4 types](https://www.figma.com/plugin-docs/api/VariableResolvedDataType) — `COLOR`, `BOOLEAN`, `FLOAT` and `STRING`. So, the plugin converts them into the corresponding types from the [DTCG 2025.10 specification](https://www.designtokens.org/tr/2025.10/format/#types).
+Unlike design tokens, Figma variables [support only 6 types](https://www.figma.com/plugin-docs/api/VariableResolvedDataType) — `COLOR`, `BOOLEAN`, `FLOAT`, `STRING`, `TIMING` and `EASING`. So, the plugin converts them into the corresponding types from the [DTCG 2025.10 specification](https://www.designtokens.org/tr/2025.10/format/#types).
 
 | Figma type | Scope condition          | Design Tokens type                                                           |
 | ---------- | ------------------------ | ---------------------------------------------------------------------------- |
@@ -1053,10 +1085,38 @@ Unlike design tokens, Figma variables now [support only 4 types](https://www.fig
 | FLOAT      | `OPACITY` scope (with %) | _string_ (e.g. `"10%"`) \*                                                   |
 | FLOAT      | all other scopes         | [dimension](https://www.designtokens.org/tr/2025.10/format/#dimension) \*\*  |
 | STRING     | —                        | _string_ \*                                                                  |
+| TIMING     | —                        | [duration](https://www.designtokens.org/tr/2025.10/format/#duration) \*\*\*   |
+| EASING     | —                        | [cubicBezier](https://www.designtokens.org/tr/2025.10/format/#cubic-bezier) or _string_ \*\*\*\* |
 
 \* native JSON types — not part of the closed DTCG 2025.10 type set. With the [DTCG 2025.10 format](#dtcg-202510-format) setting on, `$type` is omitted for `string`/`boolean` tokens and the original Figma type is preserved under `$extensions.figmaType`. Also see [this issue](https://github.com/design-tokens/community-group/issues/120#issuecomment-1279527414).
 
 \*\* Figma currently supports only `FLOAT` for numeric values used as dimensions, which map to `px` units. With the DTCG 2025.10 format on, dimensions are exported as `{ "value": 6, "unit": "px" }` objects; otherwise the plugin appends `px` to the number.
+
+\*\*\* Figma stores timings in seconds; the plugin converts them to milliseconds. With the DTCG 2025.10 format on, durations are exported as `{ "value": 300, "unit": "ms" }` objects; otherwise the plugin appends `ms` to the number.
+
+\*\*\*\* See [Motion variables](#motion-variables) below.
+
+---
+
+## Motion variables
+
+Figma's `EASING` variables hold either a custom curve or one of Figma's presets. The API returns numbers only for the two custom types — every preset arrives as just a name — so the plugin maps them like this:
+
+| Figma easing                                                                         | Token type            | Example value              |
+| ------------------------------------------------------------------------------------ | --------------------- | -------------------------- |
+| Custom bezier                                                                          | `cubicBezier`         | `[0, 0, 0.58, 1]`          |
+| Linear, Ease in / out / in and out, Ease in / out / in and out back                    | `cubicBezier`         | `[0.41, 0, 1, 1]`          |
+| Linear, Ease in / out / in and out, Ease in / out / in and out back — expansion off    | `string`              | `"ease-in"`                |
+| Gentle, Quick, Bouncy, Slow                                                            | `string`              | `"gentle"`                 |
+| Custom spring                                                                          | `string`              | `"spring(bounce 0.35)"`    |
+| Hold                                                                                   | `string`              | `"hold"`                   |
+
+Named bezier presets are expanded into curves unless [Expand easing presets to cubic-bezier](#expand-easing-presets-to-cubic-bezier) is turned off. Springs and Hold are always names: DTCG has no spring type, and Figma exposes no numbers for them.
+
+All of these forms are read back on import, so a round trip through the plugin preserves the original preset — including expanded curves, which are matched back to the preset they came from. Springs and Hold are the exception: they are indistinguishable from ordinary text on the way back in, so importing them creates `STRING` variables rather than `EASING` ones.
+
+> [!NOTE]
+> Figma does not publish the control points behind its named bezier presets, and the plugin API does not return them. The curves the plugin expands to are taken from Figma's own custom-bezier editor; if one of them does not match what you see in your file, please [open an issue](https://github.com/tokens-bruecke/figma-plugin/issues).
 
 ---
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -97,6 +97,7 @@ interface ExportSettingsI {
   storeStyleInCollection: string;
   includeFigmaMetaData: boolean;
   usePercentageOpacity: boolean;
+  expandEasingPresets: boolean;
   splitByCollection: boolean;
   splitByMode: boolean;
   omitCollectionNames: boolean;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@codemirror/search": "^6.7.1",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.6",
-    "@figma/plugin-typings": "^1.100.0",
+    "@figma/plugin-typings": "^1.137.0",
     "@figma/rest-api-spec": "^0.25.0",
     "@lezer/highlight": "^1.2.3",
     "@octokit/core": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokens-bruecke",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/plugin-types.d.ts
+++ b/plugin-types.d.ts
@@ -49,7 +49,7 @@ declare global {
 
   type DimensionStringType = string | number
 
-  type DurationStringType = string
+  type DurationStringType = string | { value: number; unit: 'ms' | 's' }
 
   type GradientTokenType = 'linear' | 'radial' | 'angular' | 'conic'
 
@@ -154,7 +154,7 @@ declare global {
 
   interface DurationTokenI extends GenericTokenI {
     $type: 'duration'
-    $value: DurationStringType // Number followed by "ms" unit
+    $value: DurationStringType // { value: 300, unit: "ms" } or "300ms"
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^6.43.6
         version: 6.43.6
       '@figma/plugin-typings':
-        specifier: ^1.100.0
-        version: 1.100.0
+        specifier: ^1.137.0
+        version: 1.137.0
       '@figma/rest-api-spec':
         specifier: ^0.25.0
         version: 0.25.0
@@ -322,8 +322,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@figma/plugin-typings@1.100.0':
-    resolution: {integrity: sha512-Dqp+yTkAjqH1cuGMhOdn7lOXTrPrjqa0sAxa5QJnsxCaBI6tjmtk5n/l/H8iv8uQ9Of0ienUoLiIrVTxgiMkdg==}
+  '@figma/plugin-typings@1.137.0':
+    resolution: {integrity: sha512-sab4AZPa5oWXjbO27UHeHWGGbl6oX+25LSXwUQIN+hoKeoeFuYeoZ7h6rCE1LZkHlvbsZjucs8wqcnOqmKiVnQ==}
 
   '@figma/rest-api-spec@0.25.0':
     resolution: {integrity: sha512-5puPZTGiWfJHlqzVQb0q+OVOkMPjE9i9nffRY24narAeRSWJn4biBwvlU6SIg7J+II2Dq0UWkLzczBac4n8g1Q==}
@@ -2314,7 +2314,7 @@ snapshots:
   '@esbuild/win32-x64@0.25.2':
     optional: true
 
-  '@figma/plugin-typings@1.100.0': {}
+  '@figma/plugin-typings@1.137.0': {}
 
   '@figma/rest-api-spec@0.25.0': {}
 

--- a/schemas/cli-options.schema.json
+++ b/schemas/cli-options.schema.json
@@ -71,6 +71,11 @@
       "default": false,
       "description": "Express opacity values as percentages instead of 0-1 numbers."
     },
+    "expandEasingPresets": {
+      "type": "boolean",
+      "default": true,
+      "description": "Expand Figma's named easing presets (Ease in, Ease out, ...) into cubicBezier token values. When false, presets keep their Figma name as a string (\"ease-in\"). Spring presets are always exported as names."
+    },
     "splitByCollection": {
       "type": "boolean",
       "default": false,

--- a/schemas/tokens-snapshot.schema.json
+++ b/schemas/tokens-snapshot.schema.json
@@ -96,7 +96,7 @@
         "resolvedType": {
           "type": "string",
           "description": "Figma variable type. Drives the token $type.",
-          "enum": ["COLOR", "FLOAT", "STRING", "BOOLEAN"]
+          "enum": ["COLOR", "FLOAT", "STRING", "BOOLEAN", "TIMING", "EASING"]
         },
         "valuesByMode": {
           "type": "object",

--- a/skills/tokens-bruecke/SKILL.md
+++ b/skills/tokens-bruecke/SKILL.md
@@ -151,7 +151,7 @@ Rules that matter:
 
 Optional JSON file passed via `--config`. Schema: [schemas/cli-options.schema.json](../../schemas/cli-options.schema.json). Example: [examples/cli-options.json](../../examples/cli-options.json).
 
-Key options (all optional): `includedStyles` (include text/effects/grids/colors styles, default all excluded), `useDTCG` (default `true`, DTCG 2025.10 `$`-keys), `colorMode` (`hex` default; also `rgba-object`, `rgba-css`, `srgb-dtcg`, `hsla-object`, `hsla-css`, `hsl-dtcg`, `oklch-dtcg`), `includeScopes`, `includeFigmaMetaData`, `usePercentageOpacity`, `storeStyleInCollection`, `splitByCollection`, `splitByMode`, `omitCollectionNames`.
+Key options (all optional): `includedStyles` (include text/effects/grids/colors styles, default all excluded), `useDTCG` (default `true`, DTCG 2025.10 `$`-keys), `colorMode` (`hex` default; also `rgba-object`, `rgba-css`, `srgb-dtcg`, `hsla-object`, `hsla-css`, `hsl-dtcg`, `oklch-dtcg`), `includeScopes`, `includeFigmaMetaData`, `usePercentageOpacity`, `expandEasingPresets` (default `true`, expands Figma's named easing presets into `cubicBezier` values), `storeStyleInCollection`, `splitByCollection`, `splitByMode`, `omitCollectionNames`.
 
 ## Output
 

--- a/src/app/controller/storageConfig.ts
+++ b/src/app/controller/storageConfig.ts
@@ -25,6 +25,7 @@ const createDefaultJSONSettingsConfig = (): JSONSettingsConfigI => ({
   includeValueStringKeyToAlias: false,
   includeFigmaMetaData: false,
   usePercentageOpacity: false,
+  expandEasingPresets: true,
   splitByCollection: false,
   splitByMode: false,
   omitCollectionNames: false,

--- a/src/app/views/AdvancedSettingsView/index.tsx
+++ b/src/app/views/AdvancedSettingsView/index.tsx
@@ -80,6 +80,17 @@ export const AdvancedSettingsView = ({
       },
     },
     {
+      id: 'expand-easing-presets',
+      label: 'Expand easing presets to cubic-bezier',
+      checked: JSONsettingsConfig.expandEasingPresets,
+      onChange: (checked: boolean) => {
+        setJSONsettingsConfig({
+          ...JSONsettingsConfig,
+          expandEasingPresets: checked,
+        });
+      },
+    },
+    {
       id: 'include-value-alias-string',
       label: (
         <>

--- a/src/cli/defaults.ts
+++ b/src/cli/defaults.ts
@@ -30,6 +30,7 @@ export const defaultConfig: ExportSettingsI = {
   includeFigmaMetaData: false,
   useDTCG: true,
   usePercentageOpacity: false,
+  expandEasingPresets: true,
   splitByCollection: false,
   splitByMode: false,
   omitCollectionNames: false,

--- a/src/cli/fileResolver.spec.ts
+++ b/src/cli/fileResolver.spec.ts
@@ -48,6 +48,7 @@ const baseConfig: ExportSettingsI = {
   includeFigmaMetaData: false,
   useDTCG: true,
   usePercentageOpacity: false,
+  expandEasingPresets: true,
   splitByCollection: false,
   splitByMode: false,
   omitCollectionNames: false,

--- a/src/common/transform/motion.spec.ts
+++ b/src/common/transform/motion.spec.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  EASING_PRESET_BEZIERS,
+  makeDuration,
+  normalizeEasing,
+  parseDurationToSeconds,
+  parseEasing,
+} from './motion';
+import { normalizeType } from './normalizeType';
+
+describe('makeDuration', () => {
+  test('converts seconds to milliseconds as a DTCG object', () => {
+    expect(makeDuration(0.3, true)).toEqual({ value: 300, unit: 'ms' });
+  });
+
+  test('converts seconds to a millisecond string in native format', () => {
+    expect(makeDuration(0.3, false)).toBe('300ms');
+  });
+
+  test('strips float32 noise coming from Figma', () => {
+    expect(makeDuration(0.30000001192092896, true)).toEqual({
+      value: 300,
+      unit: 'ms',
+    });
+  });
+
+  test('keeps sub-millisecond precision', () => {
+    expect(makeDuration(0.0166667, true)).toEqual({
+      value: 16.667,
+      unit: 'ms',
+    });
+  });
+});
+
+describe('normalizeEasing', () => {
+  test('exports a custom bezier as a cubicBezier array', () => {
+    expect(
+      normalizeEasing(
+        {
+          type: 'CUSTOM_CUBIC_BEZIER',
+          easingFunctionCubicBezier: {
+            x1: 0,
+            y1: 0,
+            x2: 0.5799999833106995,
+            y2: 1,
+          },
+        },
+        true
+      )
+    ).toEqual({ type: 'cubicBezier', value: [0, 0, 0.58, 1] });
+  });
+
+  test('expands a named preset when the setting is on', () => {
+    expect(normalizeEasing({ type: 'EASE_IN' }, true)).toEqual({
+      type: 'cubicBezier',
+      value: EASING_PRESET_BEZIERS.EASE_IN,
+    });
+  });
+
+  test('keeps a named preset as a string when the setting is off', () => {
+    expect(normalizeEasing({ type: 'EASE_IN' }, false)).toEqual({
+      type: 'string',
+      value: 'ease-in',
+    });
+  });
+
+  test('always exports spring presets as names', () => {
+    expect(normalizeEasing({ type: 'GENTLE' }, true)).toEqual({
+      type: 'string',
+      value: 'gentle',
+    });
+    expect(normalizeEasing({ type: 'HOLD' }, true)).toEqual({
+      type: 'string',
+      value: 'hold',
+    });
+  });
+
+  test('carries the bounce value of a custom spring', () => {
+    expect(
+      normalizeEasing(
+        { type: 'CUSTOM_SPRING', easingFunctionSpring: { bounce: 0.35 } },
+        true
+      )
+    ).toEqual({ type: 'string', value: 'spring(bounce 0.35)' });
+  });
+});
+
+describe('normalizeType', () => {
+  test('TIMING resolves to duration', () => {
+    expect(normalizeType('TIMING', [])).toBe('duration');
+  });
+
+  test('EASING resolves by the preset it holds', () => {
+    expect(normalizeType('EASING', [], false, { type: 'EASE_IN' }, true)).toBe(
+      'cubicBezier'
+    );
+    expect(normalizeType('EASING', [], false, { type: 'EASE_IN' }, false)).toBe(
+      'string'
+    );
+    expect(normalizeType('EASING', [], false, { type: 'BOUNCY' }, true)).toBe(
+      'string'
+    );
+  });
+});
+
+describe('parseDurationToSeconds', () => {
+  test('reads DTCG duration objects', () => {
+    expect(parseDurationToSeconds({ value: 300, unit: 'ms' })).toBe(0.3);
+    expect(parseDurationToSeconds({ value: 0.3, unit: 's' })).toBe(0.3);
+  });
+
+  test('reads duration strings and bare numbers', () => {
+    expect(parseDurationToSeconds('300ms')).toBe(0.3);
+    expect(parseDurationToSeconds('0.3s')).toBe(0.3);
+    expect(parseDurationToSeconds(300)).toBe(0.3);
+  });
+
+  test('throws on unparseable values', () => {
+    expect(() => parseDurationToSeconds('quickly')).toThrow();
+  });
+});
+
+describe('parseEasing', () => {
+  test('reads a custom bezier array', () => {
+    expect(parseEasing([0.1, 0.2, 0.3, 0.4])).toEqual({
+      type: 'CUSTOM_CUBIC_BEZIER',
+      easingFunctionCubicBezier: { x1: 0.1, y1: 0.2, x2: 0.3, y2: 0.4 },
+    });
+  });
+
+  test('matches an expanded preset back to the preset', () => {
+    expect(parseEasing(EASING_PRESET_BEZIERS.EASE_IN)).toEqual({
+      type: 'EASE_IN',
+    });
+  });
+
+  test('reads preset names', () => {
+    expect(parseEasing('ease-in-and-out')).toEqual({
+      type: 'EASE_IN_AND_OUT',
+    });
+    expect(parseEasing('bouncy')).toEqual({ type: 'BOUNCY' });
+    expect(parseEasing('hold')).toEqual({ type: 'HOLD' });
+  });
+
+  test('reads a custom spring', () => {
+    expect(parseEasing('spring(bounce 0.35)')).toEqual({
+      type: 'CUSTOM_SPRING',
+      easingFunctionSpring: { bounce: 0.35 },
+    });
+  });
+
+  test('throws on unparseable values', () => {
+    expect(() => parseEasing('wobbly')).toThrow();
+  });
+});
+
+describe('round trip', () => {
+  test('a custom bezier survives export and import', () => {
+    const exported = normalizeEasing(
+      {
+        type: 'CUSTOM_CUBIC_BEZIER',
+        easingFunctionCubicBezier: { x1: 0.25, y1: 0.1, x2: 0.25, y2: 1 },
+      },
+      true
+    );
+    expect(parseEasing(exported.value)).toEqual({
+      type: 'CUSTOM_CUBIC_BEZIER',
+      easingFunctionCubicBezier: { x1: 0.25, y1: 0.1, x2: 0.25, y2: 1 },
+    });
+  });
+
+  test.each([
+    'LINEAR',
+    'EASE_IN',
+    'EASE_OUT',
+    'EASE_IN_AND_OUT',
+    'EASE_IN_BACK',
+    'EASE_OUT_BACK',
+    'EASE_IN_AND_OUT_BACK',
+    'GENTLE',
+    'QUICK',
+    'BOUNCY',
+    'SLOW',
+    'HOLD',
+  ] as const)('preset %s survives export and import', (type) => {
+    for (const expandEasingPresets of [true, false]) {
+      const exported = normalizeEasing({ type }, expandEasingPresets);
+      expect(parseEasing(exported.value)).toEqual({ type });
+    }
+  });
+
+  test('a duration survives export and import', () => {
+    const exported = makeDuration(0.30000001192092896, true);
+    expect(parseDurationToSeconds(exported)).toBe(0.3);
+  });
+});

--- a/src/common/transform/motion.ts
+++ b/src/common/transform/motion.ts
@@ -1,0 +1,223 @@
+import Decimal from 'decimal.js';
+
+export interface DurationValueI {
+  value: number;
+  unit: 'ms';
+}
+
+export type CubicBezierValueI = [number, number, number, number];
+
+type MotionEasingType = MotionEasing['type'];
+
+/**
+ * Cubic-bezier equivalents of Figma's named easing presets.
+ *
+ * Figma's API only returns numbers for `CUSTOM_CUBIC_BEZIER` — named presets
+ * arrive as `{ type: 'EASE_IN' }` with no curve attached, and Figma does not
+ * publish their control points. To read a preset's real values, set an easing
+ * variable to that preset in Figma and switch it to "Custom bezier".
+ *
+ * `LINEAR` is exact. The rest are community-sourced; the `*_BACK` entries in
+ * particular are the least confirmed.
+ */
+export const EASING_PRESET_BEZIERS: Partial<
+  Record<MotionEasingType, CubicBezierValueI>
+> = {
+  LINEAR: [0, 0, 1, 1],
+  EASE_IN: [0.41, 0, 1, 1],
+  EASE_OUT: [0, 0, 0.59, 1],
+  EASE_IN_AND_OUT: [0.41, 0, 0.59, 1],
+  EASE_IN_BACK: [0.3, -0.05, 0.7, -0.5],
+  EASE_OUT_BACK: [0.45, 1.45, 0.8, 1],
+  EASE_IN_AND_OUT_BACK: [0.7, -0.4, 0.4, 1.4],
+};
+
+/**
+ * Readable names used when a preset is not expanded into a curve. Springs and
+ * `HOLD` always fall back to these — Figma exposes no numbers to expand them
+ * into, so the name is all there is to export.
+ */
+export const EASING_PRESET_NAMES: Record<MotionEasingType, string> = {
+  LINEAR: 'linear',
+  EASE_IN: 'ease-in',
+  EASE_OUT: 'ease-out',
+  EASE_IN_AND_OUT: 'ease-in-and-out',
+  EASE_IN_BACK: 'ease-in-back',
+  EASE_OUT_BACK: 'ease-out-back',
+  EASE_IN_AND_OUT_BACK: 'ease-in-and-out-back',
+  GENTLE: 'gentle',
+  QUICK: 'quick',
+  BOUNCY: 'bouncy',
+  SLOW: 'slow',
+  HOLD: 'hold',
+  CUSTOM_CUBIC_BEZIER: 'custom-bezier',
+  CUSTOM_SPRING: 'custom-spring',
+};
+
+/** Matches the `spring(bounce 0.35)` form produced by `normalizeEasing`. */
+const CUSTOM_SPRING_PATTERN = /^spring\(\s*bounce\s+(-?\d*\.?\d+)\s*\)$/i;
+
+// Figma stores motion values as 32-bit floats, so a 0.3s duration comes back
+// as 0.30000001192092896. Rounding at these precisions removes the noise
+// without touching any value a designer could have entered.
+const DURATION_DECIMALS = 3;
+const BEZIER_DECIMALS = 6;
+
+const round = (value: number, decimals: number): number =>
+  new Decimal(value).toDecimalPlaces(decimals).toNumber();
+
+const isMotionEasing = (value: any): value is MotionEasing =>
+  typeof value === 'object' && value !== null && typeof value.type === 'string';
+
+/**
+ * Formats a Figma TIMING value (seconds) as a duration token.
+ * - DTCG 2025.10: `{ value: 300, unit: "ms" }`
+ * - Native (legacy): `"300ms"`
+ */
+export const makeDuration = (
+  seconds: number,
+  useDTCG: boolean
+): DurationValueI | string => {
+  const milliseconds = round(Number(seconds) * 1000, DURATION_DECIMALS);
+
+  if (useDTCG) {
+    return { value: milliseconds, unit: 'ms' };
+  }
+
+  return `${milliseconds}ms`;
+};
+
+/**
+ * Converts a Figma EASING value into a token type and value.
+ *
+ * Custom beziers always export as a `cubicBezier` array. Named bezier presets
+ * do too when `expandEasingPresets` is on, using {@link EASING_PRESET_BEZIERS};
+ * otherwise they keep their Figma name as a string. Springs and `HOLD` are
+ * always strings — DTCG has no spring type, and Figma gives no curve to
+ * approximate one with.
+ */
+export const normalizeEasing = (
+  easing: any,
+  expandEasingPresets: boolean
+): { type: 'cubicBezier' | 'string'; value: CubicBezierValueI | string } => {
+  if (!isMotionEasing(easing)) {
+    return { type: 'string', value: String(easing) };
+  }
+
+  if (easing.type === 'CUSTOM_CUBIC_BEZIER' && easing.easingFunctionCubicBezier) {
+    const { x1, y1, x2, y2 } = easing.easingFunctionCubicBezier;
+    return {
+      type: 'cubicBezier',
+      value: [x1, y1, x2, y2].map((point) =>
+        round(point, BEZIER_DECIMALS)
+      ) as CubicBezierValueI,
+    };
+  }
+
+  if (easing.type === 'CUSTOM_SPRING') {
+    const bounce = easing.easingFunctionSpring?.bounce;
+    return {
+      type: 'string',
+      value:
+        typeof bounce === 'number'
+          ? `spring(bounce ${round(bounce, BEZIER_DECIMALS)})`
+          : EASING_PRESET_NAMES.CUSTOM_SPRING,
+    };
+  }
+
+  const presetBezier = EASING_PRESET_BEZIERS[easing.type];
+  if (expandEasingPresets && presetBezier) {
+    return { type: 'cubicBezier', value: presetBezier };
+  }
+
+  return {
+    type: 'string',
+    value: EASING_PRESET_NAMES[easing.type] ?? String(easing.type),
+  };
+};
+
+/**
+ * Parses a duration token value back into the seconds Figma stores.
+ * Accepts `{ value: 300, unit: "ms" }`, `"300ms"`, `"0.3s"` and bare numbers
+ * (treated as milliseconds, matching this plugin's own export).
+ */
+export const parseDurationToSeconds = (value: any): number => {
+  if (typeof value === 'object' && value !== null) {
+    const amount = Number(value.value);
+    if (Number.isNaN(amount)) {
+      throw new Error(`Unsupported duration value: ${JSON.stringify(value)}`);
+    }
+    return value.unit === 's' ? amount : amount / 1000;
+  }
+
+  if (typeof value === 'string') {
+    const match = value.trim().match(/^(-?\d*\.?\d+)\s*(ms|s)?$/i);
+    if (!match) {
+      throw new Error(`Unsupported duration value: ${value}`);
+    }
+    const amount = Number(match[1]);
+    return match[2]?.toLowerCase() === 's' ? amount : amount / 1000;
+  }
+
+  const amount = Number(value);
+  if (Number.isNaN(amount)) {
+    throw new Error(`Unsupported duration value: ${JSON.stringify(value)}`);
+  }
+  return amount / 1000;
+};
+
+/**
+ * Parses an easing token value back into a Figma `MotionEasing`.
+ *
+ * Understands the three shapes this plugin exports — a `cubicBezier` array, a
+ * preset name (`"ease-in"`, `"gentle"`, `"hold"`) and `"spring(bounce 0.35)"`.
+ * Curve arrays are matched against {@link EASING_PRESET_BEZIERS} first so an
+ * expanded preset round-trips back to the preset rather than a custom bezier.
+ */
+export const parseEasing = (value: any): MotionEasing => {
+  if (Array.isArray(value) && value.length === 4) {
+    const [x1, y1, x2, y2] = value.map(Number);
+    if ([x1, y1, x2, y2].some(Number.isNaN)) {
+      throw new Error(`Unsupported easing value: ${JSON.stringify(value)}`);
+    }
+
+    const preset = (
+      Object.keys(EASING_PRESET_BEZIERS) as MotionEasingType[]
+    ).find((type) =>
+      EASING_PRESET_BEZIERS[type].every((point, index) => point === value[index])
+    );
+    if (preset) {
+      return { type: preset };
+    }
+
+    return {
+      type: 'CUSTOM_CUBIC_BEZIER',
+      easingFunctionCubicBezier: { x1, y1, x2, y2 },
+    };
+  }
+
+  if (typeof value === 'string') {
+    const springMatch = value.trim().match(CUSTOM_SPRING_PATTERN);
+    if (springMatch) {
+      return {
+        type: 'CUSTOM_SPRING',
+        easingFunctionSpring: { bounce: Number(springMatch[1]) },
+      };
+    }
+
+    const normalizedName = value.trim().toLowerCase();
+    const preset = (
+      Object.keys(EASING_PRESET_NAMES) as MotionEasingType[]
+    ).find((type) => EASING_PRESET_NAMES[type] === normalizedName);
+    if (preset) {
+      return { type: preset };
+    }
+  }
+
+  if (isMotionEasing(value)) {
+    // Already a Figma easing object (e.g. re-importing an untouched export)
+    return value;
+  }
+
+  throw new Error(`Unsupported easing value: ${JSON.stringify(value)}`);
+};

--- a/src/common/transform/normalizeType.ts
+++ b/src/common/transform/normalizeType.ts
@@ -1,7 +1,13 @@
+import { normalizeEasing } from './motion';
+
 export const normalizeType = (
   type: VariableResolvedDataType,
   variableScopes: VariableScope[],
-  usePercentageOpacity: boolean = false
+  usePercentageOpacity: boolean = false,
+  // EASING variables resolve to `cubicBezier` or `string` depending on which
+  // preset they hold, so the value is needed to pick the type.
+  variableValue?: any,
+  expandEasingPresets: boolean = true
 ) => {
   switch (type) {
     case 'COLOR':
@@ -24,6 +30,10 @@ export const normalizeType = (
       return 'string';
     case 'BOOLEAN':
       return 'boolean';
+    case 'TIMING':
+      return 'duration';
+    case 'EASING':
+      return normalizeEasing(variableValue, expandEasingPresets).type;
     default:
       return 'string';
   }

--- a/src/common/transform/normalizeValue.ts
+++ b/src/common/transform/normalizeValue.ts
@@ -3,6 +3,7 @@ import { IResolver } from '@common/resolver';
 import { convertRGBA } from './color/convertRGBA';
 import { getAliasVariableName } from './getAliasVariableName';
 import { makeDimension } from './makeDimension';
+import { makeDuration, normalizeEasing } from './motion';
 
 interface PropsI {
   variableValue: any;
@@ -13,6 +14,7 @@ interface PropsI {
   includeValueStringKeyToAlias: boolean;
   usePercentageOpacity: boolean;
   omitCollectionNames?: boolean;
+  expandEasingPresets?: boolean;
 }
 
 export const normalizeValue = async (props: PropsI, resolver: IResolver) => {
@@ -25,6 +27,7 @@ export const normalizeValue = async (props: PropsI, resolver: IResolver) => {
     includeValueStringKeyToAlias,
     usePercentageOpacity,
     omitCollectionNames = false,
+    expandEasingPresets = true,
   } = props;
 
   // console.log("variableValue", variableValue);
@@ -62,6 +65,15 @@ export const normalizeValue = async (props: PropsI, resolver: IResolver) => {
         useDTCG
       );
     }
+  }
+
+  if (variableType === 'TIMING') {
+    // Figma stores durations in seconds, design tokens use milliseconds
+    return makeDuration(variableValue, useDTCG);
+  }
+
+  if (variableType === 'EASING') {
+    return normalizeEasing(variableValue, expandEasingPresets).value;
   }
 
   return variableValue;

--- a/src/common/transform/tokensToVariables.spec.ts
+++ b/src/common/transform/tokensToVariables.spec.ts
@@ -269,8 +269,13 @@ describe('mapTokenTypeToFigmaType', () => {
     expect(mapTokenTypeToFigmaType('opacity')).toBe('FLOAT');
   });
 
+  test('maps motion types', () => {
+    expect(mapTokenTypeToFigmaType('duration')).toBe('TIMING');
+    expect(mapTokenTypeToFigmaType('cubicBezier')).toBe('EASING');
+  });
+
   test('falls back to STRING for unknown types', () => {
-    expect(mapTokenTypeToFigmaType('duration')).toBe('STRING');
+    expect(mapTokenTypeToFigmaType('shadow')).toBe('STRING');
   });
 });
 

--- a/src/common/transform/tokensToVariables.ts
+++ b/src/common/transform/tokensToVariables.ts
@@ -1,4 +1,5 @@
 import { IResolver } from '@common/resolver';
+import { parseDurationToSeconds, parseEasing } from './motion';
 
 interface ImportResult {
   success: boolean;
@@ -303,6 +304,13 @@ export const convertTokenValueToFigmaValue = (
       }
       return parseFloat(value);
 
+    case 'duration':
+      // Design tokens use milliseconds, Figma stores TIMING in seconds
+      return parseDurationToSeconds(value);
+
+    case 'cubicBezier':
+      return parseEasing(value);
+
     case 'boolean':
       return Boolean(value);
 
@@ -337,6 +345,8 @@ export const mapTokenTypeToFigmaType = (
     opacity: 'FLOAT',
     boolean: 'BOOLEAN',
     string: 'STRING',
+    duration: 'TIMING',
+    cubicBezier: 'EASING',
   };
 
   return typeMap[tokenType] || 'STRING';

--- a/src/common/transform/variablesToTokens.spec.ts
+++ b/src/common/transform/variablesToTokens.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 
 import { variablesToTokens } from './variablesToTokens';
 import { IResolver } from '@common/resolver';
+import { EASING_PRESET_BEZIERS } from './motion';
 
 const collections = [
   {
@@ -52,6 +53,7 @@ const baseConfig = {
   includeValueStringKeyToAlias: false,
   includeFigmaMetaData: false,
   usePercentageOpacity: false,
+  expandEasingPresets: true,
   omitCollectionNames: false,
   includeScopes: false,
 } as ExportSettingsI;
@@ -97,6 +99,159 @@ describe('variablesToTokens DTCG 2025.10 format', () => {
     const brand = tokens['core']['content']['brand'];
     expect(brand.type).toBe('string');
     expect(brand.value).toBe('Acme');
+  });
+});
+
+describe('variablesToTokens motion variables', () => {
+  const motionCollections = [
+    {
+      id: 'c1',
+      name: 'motion',
+      defaultModeId: 'm1',
+      modes: [{ modeId: 'm1', name: 'default' }],
+    },
+  ] as unknown as VariableCollection[];
+
+  const motionVariables = [
+    {
+      name: 'duration/medium',
+      resolvedType: 'TIMING',
+      scopes: [],
+      variableCollectionId: 'c1',
+      // float32 noise, exactly as Figma reports 0.3s
+      valuesByMode: { m1: 0.30000001192092896 },
+      description: '',
+      codeSyntax: {},
+      id: 'v1',
+    },
+    {
+      name: 'easing/custom',
+      resolvedType: 'EASING',
+      scopes: [],
+      variableCollectionId: 'c1',
+      valuesByMode: {
+        m1: {
+          type: 'CUSTOM_CUBIC_BEZIER',
+          easingFunctionCubicBezier: {
+            x1: 0,
+            y1: 0,
+            x2: 0.5799999833106995,
+            y2: 1,
+          },
+        },
+      },
+      description: '',
+      codeSyntax: {},
+      id: 'v2',
+    },
+    {
+      name: 'easing/preset',
+      resolvedType: 'EASING',
+      scopes: [],
+      variableCollectionId: 'c1',
+      valuesByMode: { m1: { type: 'EASE_IN' } },
+      description: '',
+      codeSyntax: {},
+      id: 'v3',
+    },
+    {
+      name: 'easing/spring',
+      resolvedType: 'EASING',
+      scopes: [],
+      variableCollectionId: 'c1',
+      valuesByMode: { m1: { type: 'GENTLE' } },
+      description: '',
+      codeSyntax: {},
+      id: 'v4',
+    },
+  ] as unknown as Variable[];
+
+  test('DTCG on: durations and easings get motion types', async () => {
+    const tokens = await variablesToTokens(
+      motionVariables,
+      motionCollections,
+      { ...baseConfig, useDTCG: true },
+      resolver
+    );
+
+    const duration = tokens['motion']['duration']['medium'];
+    expect(duration.$type).toBe('duration');
+    expect(duration.$value).toStrictEqual({ value: 300, unit: 'ms' });
+
+    const custom = tokens['motion']['easing']['custom'];
+    expect(custom.$type).toBe('cubicBezier');
+    expect(custom.$value).toStrictEqual([0, 0, 0.58, 1]);
+
+    const preset = tokens['motion']['easing']['preset'];
+    expect(preset.$type).toBe('cubicBezier');
+    expect(preset.$value).toStrictEqual(EASING_PRESET_BEZIERS.EASE_IN);
+
+    // Springs have no DTCG equivalent and always export as names
+    const spring = tokens['motion']['easing']['spring'];
+    expect(spring.$type).toBe('string');
+    expect(spring.$value).toBe('gentle');
+  });
+
+  test('expandEasingPresets off: named presets keep their Figma name', async () => {
+    const tokens = await variablesToTokens(
+      motionVariables,
+      motionCollections,
+      { ...baseConfig, useDTCG: true, expandEasingPresets: false },
+      resolver
+    );
+
+    const preset = tokens['motion']['easing']['preset'];
+    expect(preset.$type).toBe('string');
+    expect(preset.$value).toBe('ease-in');
+
+    // Custom beziers carry real numbers and are unaffected by the setting
+    const custom = tokens['motion']['easing']['custom'];
+    expect(custom.$type).toBe('cubicBezier');
+    expect(custom.$value).toStrictEqual([0, 0, 0.58, 1]);
+  });
+
+  test('DTCG off: durations use the legacy ms string', async () => {
+    const tokens = await variablesToTokens(
+      motionVariables,
+      motionCollections,
+      { ...baseConfig, useDTCG: false },
+      resolver
+    );
+
+    const duration = tokens['motion']['duration']['medium'];
+    expect(duration.type).toBe('duration');
+    expect(duration.value).toBe('300ms');
+  });
+
+  test('an aliased easing takes its type from the variable it points at', async () => {
+    const springVariable = motionVariables[3];
+    const aliasVariable = {
+      name: 'easing/alias',
+      resolvedType: 'EASING',
+      scopes: [],
+      variableCollectionId: 'c1',
+      valuesByMode: { m1: { type: 'VARIABLE_ALIAS', id: 'v4' } },
+      description: '',
+      codeSyntax: {},
+      id: 'v5',
+    } as unknown as Variable;
+
+    const aliasResolver = {
+      getVariableById: async (id: string) =>
+        id === 'v4' ? springVariable : null,
+      getVariableCollectionById: async () => motionCollections[0],
+    } as unknown as IResolver;
+
+    const tokens = await variablesToTokens(
+      [springVariable, aliasVariable],
+      motionCollections,
+      { ...baseConfig, useDTCG: true },
+      aliasResolver
+    );
+
+    const alias = tokens['motion']['easing']['alias'];
+    expect(alias.$type).toBe('string');
+    expect(alias.$value).toBe('{motion.easing.spring}');
   });
 });
 

--- a/src/common/transform/variablesToTokens.ts
+++ b/src/common/transform/variablesToTokens.ts
@@ -7,6 +7,35 @@ import { IResolver } from '@common/resolver';
 
 // console.clear();
 
+const MAX_ALIAS_DEPTH = 10;
+
+/**
+ * Follows a chain of variable aliases down to the concrete value behind it,
+ * reading each target's default mode. Returns the value unchanged when it is
+ * not an alias, or when the chain cannot be resolved.
+ */
+const resolveAliasedValue = async (
+  value: any,
+  resolver: IResolver,
+  depth = 0
+): Promise<any> => {
+  if (value?.type !== 'VARIABLE_ALIAS' || depth >= MAX_ALIAS_DEPTH) {
+    return value;
+  }
+
+  const target = await resolver.getVariableById(value.id);
+  if (!target) {
+    return value;
+  }
+
+  const collection = await resolver.getVariableCollectionById(
+    target.variableCollectionId
+  );
+  const modeId = collection?.defaultModeId ?? Object.keys(target.valuesByMode)[0];
+
+  return resolveAliasedValue(target.valuesByMode[modeId], resolver, depth + 1);
+};
+
 export const variablesToTokens = async (
   variables: Variable[],
   collections: VariableCollection[],
@@ -20,6 +49,7 @@ export const variablesToTokens = async (
     includeFigmaMetaData,
     usePercentageOpacity,
     omitCollectionNames = false,
+    expandEasingPresets = true,
   } = config;
   const keyNames = getTokenKeyName(useDTCG);
 
@@ -86,6 +116,7 @@ export const variablesToTokens = async (
           includeValueStringKeyToAlias,
           usePercentageOpacity,
           omitCollectionNames,
+          expandEasingPresets,
         },
         resolver
       );
@@ -117,10 +148,23 @@ export const variablesToTokens = async (
     const filteredModesValues =
       Object.keys(modesValues).length === 1 ? {} : modesValues;
 
+    // EASING variables map to `cubicBezier` or `string` depending on the
+    // preset they hold, so aliases have to be followed to their real value
+    // before the token type can be decided.
+    const rawDefaultValue =
+      variable.resolvedType === 'EASING'
+        ? await resolveAliasedValue(
+            variable.valuesByMode[collectionDefaultModeId],
+            resolver
+          )
+        : variable.valuesByMode[collectionDefaultModeId];
+
     const tokenType = normalizeType(
       variable.resolvedType,
       variable.scopes,
-      usePercentageOpacity
+      usePercentageOpacity,
+      rawDefaultValue,
+      expandEasingPresets
     );
 
     const variableObject = {


### PR DESCRIPTION
Closes #85.

Figma 1.133 added motion variables, so `VariableResolvedDataType` now includes `TIMING` and `EASING`. Until now both fell through to the `default` branch of `normalizeType` and exported as `$type: "string"` wrapping either a raw seconds float or a raw Figma easing object.

## Export

| Figma | Token |
| --- | --- |
| `TIMING` | `{ "$type": "duration", "$value": { "value": 300, "unit": "ms" } }` |
| Custom bezier | `{ "$type": "cubicBezier", "$value": [0, 0, 0.58, 1] }` |
| Named bezier preset | `cubicBezier` when expanded, otherwise `"ease-in"` |
| Gentle / Quick / Bouncy / Slow | `"gentle"` |
| Custom spring | `"spring(bounce 0.35)"` |
| Hold | `"hold"` |

Figma stores timings in seconds; they are converted to milliseconds. Values are rounded to strip float32 noise, so `0.30000001192092896 s` becomes `300 ms` and `0.5799999833106995` becomes `0.58`. Non-DTCG mode emits `"300ms"`, matching how dimensions already emit `"6px"`.

## The preset problem

The plugin API returns numbers only for `CUSTOM_CUBIC_BEZIER` and `CUSTOM_SPRING`. Every named preset arrives as just its name, and Figma does not publish the curves behind them.

New `expandEasingPresets` setting (default on) expands the named bezier presets through a lookup table so they export as spec-valid `cubicBezier`; turned off, they keep their Figma name and round-trip exactly. Springs and Hold are always names regardless — DTCG has no spring type and there is no curve to expand them into.

Since `EASING` resolves to two different token types, aliases are followed to their target's real value before the type is picked, so an alias pointing at a spring is typed `string` rather than `cubicBezier`.

> [!NOTE]
> Only `LINEAR` in `EASING_PRESET_BEZIERS` is certain. The other six are community-sourced and flagged as unverified in the code — the three `*_BACK` curves most of all. Worth confirming against Figma's custom-bezier editor and correcting in a patch.

## Import

`duration -> TIMING` and `cubicBezier -> EASING`, values converted back to seconds and `MotionEasing`. Expanded curves are matched against the preset table on the way in, so `EASE_IN` round-trips to `EASE_IN` rather than degrading into a custom bezier. Springs and Hold are the gap: as plain strings they are indistinguishable from ordinary text, so they re-import as `STRING` variables. Documented rather than guessed at.

## Notes

- Requires `@figma/plugin-typings` 1.137 (from 1.100), which is where the new resolved types and `MotionEasing` land.
- 33 unit tests plus 4 end-to-end cases, including a round trip over all 12 presets in both toggle states. Suite at 173 passing, both webpack builds clean.
- Docs: new "Motion variables" README section, the settings entry, the conversion table, config schema, snapshot schema and the agent skill doc.