### PR TITLE
fix(profiles): stop startup race that wiped stored profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokens-bruecke",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/app/container.tsx
+++ b/src/app/container.tsx
@@ -36,6 +36,7 @@ const Container = () => {
 
   const [multiTenantConfig, setMultiTenantConfig] =
     useState<MultiTenantConfigI>(createDefaultConfig());
+  const [isStorageLoaded, setIsStorageLoaded] = useState(false);
 
   const activeProfileId = multiTenantConfig.activeProfileId;
   const JSONsettingsConfig =
@@ -204,13 +205,22 @@ const Container = () => {
   // USE EFFECTS //
   /////////////////
 
-  // Get all collections from Figma
+  // Load stored config and collections from Figma
   useEffect(() => {
-    parent.postMessage({ pluginMessage: { type: 'checkForVariables' } }, '*');
+    const handleMessage = (event: MessageEvent) => {
+      const message = event.data?.pluginMessage;
+      if (!message) return;
 
-    window.onmessage = (event) => {
       const { type, hasVariables, variableCollections, storageConfig } =
-        event.data.pluginMessage;
+        message;
+
+      // stored config arrives first; only then may the UI write back
+      if (type === 'storageConfig') {
+        if (storageConfig) {
+          setMultiTenantConfig(sanitizeMultiTenantConfig(storageConfig));
+        }
+        setIsStorageLoaded(true);
+      }
 
       // check if file has variables
       if (type === 'checkForVariables') {
@@ -218,19 +228,30 @@ const Container = () => {
         setIsLoading(false);
 
         if (hasVariables) {
-          setJSONsettingsConfig((prev) => ({
+          setMultiTenantConfig((prev) => ({
             ...prev,
-            variableCollections,
+            profiles: Object.keys(prev.profiles).reduce(
+              (acc, profileId) => {
+                acc[profileId] = {
+                  ...prev.profiles[profileId],
+                  variableCollections,
+                };
+                return acc;
+              },
+              {} as Record<ProfileId, SettingsProfileI>
+            ),
           }));
         }
       }
+    };
 
-      // check storage on load
-      if (type === 'storageConfig') {
-        if (storageConfig) {
-          setMultiTenantConfig(sanitizeMultiTenantConfig(storageConfig));
-        }
-      }
+    window.addEventListener('message', handleMessage);
+
+    parent.postMessage({ pluginMessage: { type: 'getStorageConfig' } }, '*');
+    parent.postMessage({ pluginMessage: { type: 'checkForVariables' } }, '*');
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
     };
   }, []);
 
@@ -297,8 +318,11 @@ const Container = () => {
     }
   }, [manualFrameHeight, contentHeight]);
 
-  // pass changed to figma controller
+  // pass changes to figma controller, but never before the stored
+  // config has been loaded, otherwise defaults would overwrite it
   useDidUpdate(() => {
+    if (!isStorageLoaded) return;
+
     parent.postMessage(
       {
         pluginMessage: {
@@ -308,7 +332,7 @@ const Container = () => {
       },
       '*'
     );
-  }, [multiTenantConfig]);
+  }, [multiTenantConfig, isStorageLoaded]);
 
   // handle code preview
   useDidUpdate(() => {

--- a/src/app/controller/getStorageConfig.ts
+++ b/src/app/controller/getStorageConfig.ts
@@ -1,6 +1,8 @@
 import { parseStoredConfig } from './storageConfig';
 
-export const getStorageConfig = async (key) => {
+export const getStorageConfig = async (
+  key: string
+): Promise<MultiTenantConfigI> => {
   const rawStorageConfig = await figma.clientStorage.getAsync(key);
   const config = parseStoredConfig(rawStorageConfig);
 
@@ -10,4 +12,6 @@ export const getStorageConfig = async (key) => {
     type: 'storageConfig',
     storageConfig: config,
   });
+
+  return config;
 };

--- a/src/app/controller/index.ts
+++ b/src/app/controller/index.ts
@@ -21,8 +21,6 @@ console.clear();
 
 const pluginConfigKey = 'tokenbrücke-config';
 
-getStorageConfig(pluginConfigKey);
-
 //
 let isCodePreviewOpen = false;
 
@@ -41,9 +39,22 @@ figma.showUI(__html__, {
 let JSONSettingsConfig: JSONSettingsConfigI;
 let multiTenantConfig: MultiTenantConfigI;
 
+const loadStorageConfig = async () => {
+  multiTenantConfig = await getStorageConfig(pluginConfigKey);
+  JSONSettingsConfig =
+    multiTenantConfig.profiles[multiTenantConfig.activeProfileId];
+};
+
+loadStorageConfig();
+
 // listen for messages from the UI
 figma.ui.onmessage = async (msg) => {
   await checkForVariables(msg.type);
+
+  // UI asks for the stored config once it is ready to receive it
+  if (msg.type === 'getStorageConfig') {
+    await loadStorageConfig();
+  }
 
   // get JSON settings config from UI and store it in a variable
   if (msg.type === 'JSONSettingsConfig') {

--- a/src/app/views/SettingsView/index.tsx
+++ b/src/app/views/SettingsView/index.tsx
@@ -283,7 +283,7 @@ export const SettingsView = (props: ViewProps) => {
 
   // Receive tokens from figma controller
   useEffect(() => {
-    window.onmessage = async (event) => {
+    const handleMessage = async (event: MessageEvent) => {
       if (!event.data?.pluginMessage) return;
       const { type, tokens, role, server, result } = event.data
         .pluginMessage as TokensMessageI;
@@ -386,6 +386,12 @@ export const SettingsView = (props: ViewProps) => {
           }
         }
       }
+    };
+
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
     };
   }, [JSONsettingsConfig]);
 


### PR DESCRIPTION
Fixes intermittent loss of profile and push-to-server settings when reopening the plugin. The UI could save its default config over the stored one before receiving it. See commit message for details.

Also bumps the version to 3.8.1 for release.