### PR TITLE
fix(ci): CHANGELOG generation for tags on merge commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,10 +72,14 @@ jobs:
             echo "CHANGELOG.md already documents ${VERSION} — skipping (safe on re-runs)."
             exit 0
           fi
-          # -r 2, not -r 1: on a tag push HEAD sits on the tag, so "the latest
-          # release" (-r 1) is the empty unreleased range and nothing is written.
-          # -r 2 reaches back one further and emits the tagged release's section.
-          npx --yes conventional-changelog-cli -p conventionalcommits -i CHANGELOG.md -s -r 2
+          # On a tag push HEAD sits on the tag, so "the latest release" would be
+          # the empty unreleased range. Hide the tag in the local clone so the
+          # range becomes <previous tag>..HEAD and the version comes from
+          # package.json. This also works when the tag is on a merge commit,
+          # where -r 2 emitted nothing because --no-merges dropped the tagged
+          # commit and the release lost its version.
+          git tag -d "${GITHUB_REF_NAME}"
+          npx --yes conventional-changelog-cli -p conventionalcommits -i CHANGELOG.md -s -r 1
           npx --yes prettier --write CHANGELOG.md
           if ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
             echo "::error::conventional-changelog produced no section for ${VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [3.8.1](https://github.com/tokens-bruecke/figma-plugin/compare/v3.7.0...v3.8.1) (2026-09-05)
+
+### Features
+
+- **motion:** export TIMING and EASING variables as DTCG motion tokens ([4b130c8](https://github.com/tokens-bruecke/figma-plugin/commit/4b130c8e97713d12534f241e6a6d53963a96937b)), closes [#85](https://github.com/tokens-bruecke/figma-plugin/issues/85)
+
+### Bug Fixes
+
+- **profiles:** stop startup race that wiped stored profiles and server settings ([6b37c18](https://github.com/tokens-bruecke/figma-plugin/commit/6b37c184a533b379693cea233a256534e61bd694))
+
 ## [3.7.0](https://github.com/tokens-bruecke/figma-plugin/compare/v3.6.0...v3.7.0) (2026-08-22)
 
 ### Features


### PR DESCRIPTION
The v3.8.1 release workflow published to npm and created the GitHub release, but the CHANGELOG step failed because the tag sits on a PR merge commit. This fixes the generator invocation and adds the missing 3.8.1 section.