### PR TITLE
feat(servers): link to the GitHub Pull Request after pushing

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -184,6 +184,10 @@ interface MetaPropsI {
 interface ToastIPropsI {
   title: string;
   message: string;
+  link?: {
+    label: string;
+    url: string;
+  };
   options: {
     type?: 'success' | 'error' | 'warn' | 'info';
     timeout?: number;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokens-bruecke",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/app/api/servers/githubPullRequest.ts
+++ b/src/app/api/servers/githubPullRequest.ts
@@ -38,13 +38,19 @@ export const githubPullRequest = async (
       await createOrUpdateBranch(commit);
       console.log('branch created or updated');
 
-      await createPullRequest();
-      console.log('pull request created');
+      const { url, created } = await createPullRequest();
+      console.log(created ? 'pull request created' : 'pull request updated');
       toastCallback({
-        title: 'Github: Updated successfully',
-        message: 'Github Pull Request has been updated successfully',
+        title: created
+          ? 'Github: Pull Request created'
+          : 'Github: Pull Request updated',
+        message: created
+          ? 'Github Pull Request has been created successfully'
+          : 'Github Pull Request has been updated successfully',
+        link: url ? { label: 'Open Pull Request', url } : undefined,
         options: {
           type: 'success',
+          timeout: 15000,
         },
       });
     } catch (error) {
@@ -126,13 +132,17 @@ export const githubPullRequest = async (
     });
   }
 
-  async function createPullRequest() {
-    if (await isPullRequestExist(branch)) {
+  async function createPullRequest(): Promise<{
+    url: string | null;
+    created: boolean;
+  }> {
+    const existing = await findExistingPullRequest(branch);
+    if (existing) {
       console.log('pull request already exist');
-      return null;
+      return { url: existing.html_url, created: false };
     }
 
-    return octokit.request('POST /repos/{owner}/{repo}/pulls', {
+    const response = await octokit.request('POST /repos/{owner}/{repo}/pulls', {
       owner,
       repo,
       title: pullRequestTitle,
@@ -140,6 +150,8 @@ export const githubPullRequest = async (
       head: branch,
       base: baseBranch,
     });
+
+    return { url: response.data.html_url, created: true };
   }
 
   async function isBrunchExist(branch: string) {
@@ -158,16 +170,19 @@ export const githubPullRequest = async (
     }
   }
 
-  async function isPullRequestExist(branch: string) {
+  async function findExistingPullRequest(branch: string) {
     const pullRequest = await octokit.request(
       'GET /repos/{owner}/{repo}/pulls',
       {
         owner,
         repo,
-        head: branch,
+        // GitHub expects "owner:branch" for the head filter;
+        // a bare branch name is silently ignored and returns every open PR.
+        head: `${owner}:${branch}`,
+        state: 'open',
       }
     );
 
-    return pullRequest.data.length > 0;
+    return pullRequest.data[0] ?? null;
   }
 };

--- a/src/app/components/Toast/index.tsx
+++ b/src/app/components/Toast/index.tsx
@@ -17,6 +17,7 @@ export const Toast = forwardRef<ToastRefI, {}>((_, ref: Ref<ToastRefI>) => {
         {
           title: params.title ?? 'Title',
           message: params.message,
+          link: params.link,
           options: {
             type: params.options?.type ?? 'info',
             timeout: params.options?.timeout ?? 5000,
@@ -66,6 +67,18 @@ export const Toast = forwardRef<ToastRefI, {}>((_, ref: Ref<ToastRefI>) => {
             </Text>
 
             <Text className={styles.message}>{toast.message}</Text>
+
+            {toast.link && (
+              <a
+                className={styles.link}
+                href={toast.link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {toast.link.label}
+              </a>
+            )}
           </div>
         ))}
       </div>

--- a/src/app/components/Toast/styles.module.scss
+++ b/src/app/components/Toast/styles.module.scss
@@ -63,6 +63,13 @@
   pointer-events: all;
 }
 
+.link {
+  color: var(--figma-color-text-brand);
+  text-decoration: underline;
+  word-break: break-all;
+  pointer-events: all;
+}
+
 .success {
   background: var(--figma-color-bg-success-tertiary);
 }


### PR DESCRIPTION
The success toast now carries an "Open Pull Request" link, both when a new PR is created and when an existing one is updated (with a longer 15s timeout so there is time to click it).

Also fixes the existing-PR lookup: GitHub expects the `head` filter as `owner:branch`, so the bare branch name was ignored and any open PR in the repo made the plugin skip creating one.

Bumps the version to 3.9.0 for release.