### PR TITLE
feat(analytics): anonymous usage events with GoatCounter, release v3.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The plugin converts Figma variables into design-tokens JSON that are compatible 
   - [Motion variables](#motion-variables)
   - [Design tokens types](#design-tokens-types)
   - [Scopes lemitations](#scopes-lemitations)
+  - [Privacy and analytics](#privacy-and-analytics)
   - [Feedback](#feedback)
 
 ---
@@ -1132,6 +1133,16 @@ In order to convert `FONT-WEIGHT` and `OPACITY` types into valid values you shou
 
 - `FONT_WEIGHT` scope will be converted into `fontWeight` type.
 - `OPACITY` scope will be converted into `number` type (or `string` with `%` if "Use percentage for opacity" is enabled).
+
+---
+
+## Privacy and analytics
+
+The plugin counts a few anonymous usage events with [GoatCounter](https://www.goatcounter.com), a privacy-friendly, open-source counter. It helps us see which features are used so we know where to focus.
+
+What is sent: the plugin was opened, the file had variables or not, tokens were downloaded, tokens were copied from the code preview, tokens were imported, or a push to one of the servers (GitHub, GitLab, JSONBin, custom URL) was started. That is the full list.
+
+What is never sent: your tokens, variable or collection names, file names, server URLs, access tokens, or any other data read from your Figma file. GoatCounter sets no cookies and does not track you across sites.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokens-bruecke",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/app/api/analytics.ts
+++ b/src/app/api/analytics.ts
@@ -1,0 +1,28 @@
+// Anonymous usage counters via GoatCounter's public pixel endpoint.
+// Only fixed event names are sent: never token data, file names, URLs,
+// or anything else read from the Figma plugin API.
+const ENDPOINT = 'https://pavellaptev.goatcounter.com/count';
+
+const isEnabled = () => process.env.NODE_ENV === 'production';
+
+/**
+ * @param path fixed event path, e.g. "/push/github"
+ * @param event true for actions, false for a "plugin opened" pageview
+ */
+export const track = (path: string, event = true) => {
+  if (!isEnabled()) return;
+
+  try {
+    const params = new URLSearchParams({
+      p: path,
+      rnd: String(Date.now()),
+    });
+    if (event) params.set('e', 'true');
+
+    fetch(`${ENDPOINT}?${params}`, { mode: 'no-cors', keepalive: true }).catch(
+      () => {}
+    );
+  } catch {
+    // analytics must never break the plugin
+  }
+};

--- a/src/app/container.tsx
+++ b/src/app/container.tsx
@@ -8,6 +8,7 @@ import { SettingsView } from './views/SettingsView';
 
 import { CodePreviewView } from './views/CodePreviewView';
 import { importTokensFile } from './api/importTokensFile';
+import { track } from './api/analytics';
 import {
   createDefaultConfig,
   createProfileFromConfig,
@@ -181,6 +182,7 @@ const Container = () => {
       const tokensData = await importTokensFile();
 
       if (tokensData) {
+        track('/import');
         // Send tokens to figma controller for import
         parent.postMessage(
           {
@@ -227,6 +229,8 @@ const Container = () => {
         setFileHasVariables(hasVariables);
         setIsLoading(false);
 
+        track(hasVariables ? '/ready' : '/empty');
+
         if (hasVariables) {
           setMultiTenantConfig((prev) => ({
             ...prev,
@@ -246,6 +250,8 @@ const Container = () => {
     };
 
     window.addEventListener('message', handleMessage);
+
+    track('/', false);
 
     parent.postMessage({ pluginMessage: { type: 'getStorageConfig' } }, '*');
     parent.postMessage({ pluginMessage: { type: 'checkForVariables' } }, '*');

--- a/src/app/views/CodePreviewView/index.tsx
+++ b/src/app/views/CodePreviewView/index.tsx
@@ -4,6 +4,7 @@ import styles from './styles.module.scss';
 
 import { getTokensStat } from '@common/transform/getTokensStat';
 import { JsonViewer } from '@app/components/JsonViewer';
+import { track } from '@app/api/analytics';
 
 import { Text, Icon } from 'react-figma-ui/ui';
 
@@ -88,6 +89,7 @@ export const CodePreviewView = ({ generatedTokens }: CodePreviewViewProps) => {
   };
 
   const copyCode = () => {
+    track('/copy');
     // copy code to clipboard
     copy(JSON.stringify(generatedTokens, null, 2));
     setIsCodeCopied(true);

--- a/src/app/views/SettingsView/index.tsx
+++ b/src/app/views/SettingsView/index.tsx
@@ -32,6 +32,7 @@ import { pushToCustomURL } from '@app/api/servers/pushToCustomURL';
 
 import { downloadTokensFile } from '@app/api/downloadTokensFile';
 import { importTokensFile } from '@app/api/importTokensFile';
+import { track } from '@app/api/analytics';
 
 type StyleListItemType = {
   id: stylesType;
@@ -227,6 +228,7 @@ export const SettingsView = (props: ViewProps) => {
       const tokensData = await importTokensFile();
 
       if (tokensData) {
+        track('/import');
         // Send tokens to figma controller for import
         parent.postMessage(
           {
@@ -295,7 +297,7 @@ export const SettingsView = (props: ViewProps) => {
         }
 
         if (role === 'download') {
-          // console.log("tokens download", tokens);
+          track('/download');
           downloadTokensFile(
             tokens,
             JSONsettingsConfig.splitByCollection,
@@ -310,6 +312,7 @@ export const SettingsView = (props: ViewProps) => {
           };
 
           if (server.includes('jsonbin')) {
+            track('/push/jsonbin');
             console.log('push to jsonbin');
             await pushToJSONBin(
               JSONsettingsConfig.servers.jsonbin,
@@ -321,6 +324,7 @@ export const SettingsView = (props: ViewProps) => {
           }
 
           if (server.includes('github')) {
+            track('/push/github');
             // console.log("github config", JSONsettingsConfig.servers.github);
             console.log('push to github');
             await pushToGithub(
@@ -334,6 +338,7 @@ export const SettingsView = (props: ViewProps) => {
           }
 
           if (server.includes('githubPullRequest')) {
+            track('/push/github-pull-request');
             console.log('create github pull request');
             await githubPullRequest(
               JSONsettingsConfig.servers.githubPullRequest,
@@ -346,6 +351,7 @@ export const SettingsView = (props: ViewProps) => {
           }
 
           if (server.includes('gitlab')) {
+            track('/push/gitlab');
             console.log('push to gitlab');
             await pushToGitlab(
               JSONsettingsConfig.servers.gitlab,
@@ -358,6 +364,7 @@ export const SettingsView = (props: ViewProps) => {
           }
 
           if (server.includes('customURL')) {
+            track('/push/custom-url');
             console.log('push to customURL');
             await pushToCustomURL(JSONsettingsConfig.servers.customURL, tokens);
           }


### PR DESCRIPTION
Adds anonymous feature-usage counters via GoatCounter's public pixel endpoint.

Events (fixed paths only): `/`, `/ready`, `/empty`, `/download`, `/copy`, `/import`, `/push/github`, `/push/github-pull-request`, `/push/gitlab`, `/push/jsonbin`, `/push/custom-url`.

No token data, variable names, file names, server URLs, or access tokens are sent. Tracking is a no-op in development builds. README gains a "Privacy and analytics" section.

Bumps version to 3.10.0.