### PR TITLE
feat(color): export color aliases with a separate opacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The plugin converts Figma variables into design-tokens JSON that are compatible 
   - [Tokens structure](#tokens-structure)
   - [Aliases handling](#aliases-handling)
     - [Include `.value` string for aliases](#include-value-string-for-aliases-1)
+    - [Color aliases with opacity](#color-aliases-with-opacity)
     - [Handle variables from another file](#handle-variables-from-another-file)
     - [Handle modes](#handle-modes)
   - [Variables types conversion](#variables-types-conversion)
@@ -558,6 +559,7 @@ Things worth knowing when building a snapshot:
 - Colors are 0..1 float channels (`{ r, g, b, a }`), as the Plugin API returns them.
 - `collection.variableIds` preserves the ordering shown in Figma's Variables panel.
 - Aliases are `{ "type": "VARIABLE_ALIAS", "id": "…" }` and must point at a variable present in the snapshot; otherwise the value exports as `"#missing#"`, matching the REST behaviour for unresolvable references.
+- Color aliases with their own opacity come back from the Plugin API as `{ "type": "VARIABLE_EXPRESSION", "expressionFunction": "COMPOSE_COLOR", "expressionArguments": [<alias or rgba>, <0..100 or alias>] }` — pass them through as-is, see [Color aliases with opacity](#color-aliases-with-opacity).
 
 > [!NOTE]
 > Plugin API objects are live proxies, so `JSON.stringify` may not enumerate their properties. Copy the fields listed in the schema onto plain objects before serializing.
@@ -1038,6 +1040,41 @@ All aliases are converted into the alias string format from the [Design Tokens s
 ### Include `.value` string for aliases
 
 You can switch on the `Include .value string for aliases` option in [the plugin settings](#include-value-string-for-aliases).
+
+---
+
+### Color aliases with opacity
+
+Since September 2026 Figma lets a color variable alias another color and apply its own opacity on top ("Control opacity at scale"). The opacity can be a plain percentage or a number variable with the `COLOR_OPACITY` scope.
+
+The [DTCG color type](https://www.designtokens.org/tr/2025.10/color/#format) has no way to express "this color, with that opacity" while keeping the reference, so the plugin exports these variables as a composite value: `components` holds the reference to the base color and `alpha` holds the opacity, as a `0..1` number (or `"50%"` with [Use percentage for opacity](#use-percentage-for-opacity)) or a reference to the number variable driving it.
+
+```json
+{
+  "opacity": {
+    "50": { "$type": "number", "$value": 0.5, "scopes": ["COLOR_OPACITY"] }
+  },
+  "color": {
+    "brand": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [0.2, 0.4, 0.8], "alpha": 1, "hex": "#3366cc" }
+    },
+    "brand-translucent": {
+      "$type": "color",
+      "$value": { "components": "{color.brand}", "alpha": 0.5 }
+    },
+    "brand-muted": {
+      "$type": "color",
+      "$value": { "components": "{color.brand}", "alpha": "{opacity.50}" }
+    }
+  }
+}
+```
+
+The `alpha` replaces the alpha channel of the referenced color. If the base color is a literal rather than an alias, the opacity is baked into the regular color value for the chosen [color mode](#color-mode); only when the opacity itself is a reference does the color value keep an `alpha` (or `a`) reference in place of the number.
+
+> [!NOTE]
+> This shape is an extension of the DTCG format, so a consumer needs a small custom transform: resolve the `components` reference, then apply `alpha`. Figma's Plugin API can read these variables but not write them yet, so they cannot be imported back through the plugin.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ When enabled, the named bezier presets (Linear, Ease in, Ease out, Ease in and o
 {
   "easing": {
     "$type": "cubicBezier",
-    "$value": [0.41, 0, 1, 1]
+    "$value": [0.42, 0, 1, 1]
   }
 }
 
@@ -201,7 +201,8 @@ When enabled, the named bezier presets (Linear, Ease in, Ease out, Ease in and o
 {
   "easing": {
     "$type": "string",
-    "$value": "ease-in"
+    "$value": "ease-in",
+    "$extensions": { "figmaType": "EASING" }
   }
 }
 ```
@@ -1145,12 +1146,12 @@ Unlike design tokens, Figma variables [support only 6 types](https://www.figma.c
 
 ## Motion variables
 
-Figma's `EASING` variables hold either a custom curve or one of Figma's presets. The API returns numbers only for the two custom types — every preset arrives as just a name — so the plugin maps them like this:
+Figma's `EASING` variables hold either a custom curve or one of Figma's presets. DTCG only has a `cubicBezier` type, so the plugin maps them like this:
 
 | Figma easing                                                                        | Token type    | Example value           |
 | ----------------------------------------------------------------------------------- | ------------- | ----------------------- |
 | Custom bezier                                                                       | `cubicBezier` | `[0, 0, 0.58, 1]`       |
-| Linear, Ease in / out / in and out, Ease in / out / in and out back                 | `cubicBezier` | `[0.41, 0, 1, 1]`       |
+| Linear, Ease in / out / in and out, Ease in / out / in and out back                 | `cubicBezier` | `[0.42, 0, 1, 1]`       |
 | Linear, Ease in / out / in and out, Ease in / out / in and out back — expansion off | `string`      | `"ease-in"`             |
 | Gentle, Quick, Bouncy, Slow                                                         | `string`      | `"gentle"`              |
 | Custom spring                                                                       | `string`      | `"spring(bounce 0.35)"` |
@@ -1158,10 +1159,10 @@ Figma's `EASING` variables hold either a custom curve or one of Figma's presets.
 
 Named bezier presets are expanded into curves unless [Expand easing presets to cubic-bezier](#expand-easing-presets-to-cubic-bezier) is turned off. Springs and Hold are always names: DTCG has no spring type, and Figma exposes no numbers for them.
 
-All of these forms are read back on import, so a round trip through the plugin preserves the original preset — including expanded curves, which are matched back to the preset they came from. Springs and Hold are the exception: they are indistinguishable from ordinary text on the way back in, so importing them creates `STRING` variables rather than `EASING` ones.
+All of these forms are read back on import, so a round trip through the plugin preserves the original preset. Expanded curves are matched back to the preset they came from, and easings exported as strings carry an `$extensions.figmaType: "EASING"` marker so they are recreated as `EASING` variables rather than `STRING` ones.
 
 > [!NOTE]
-> Figma does not publish the control points behind its named bezier presets, and the plugin API does not return them. The curves the plugin expands to are taken from Figma's own custom-bezier editor; if one of them does not match what you see in your file, please [open an issue](https://github.com/tokens-bruecke/figma-plugin/issues).
+> The curves of the named bezier presets are the ones Figma attaches to the preset in the Plugin API; if one of them does not match what you see in your file, please [open an issue](https://github.com/tokens-bruecke/figma-plugin/issues).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1081,6 +1081,9 @@ The `alpha` is the opacity Figma applies on top of the referenced color. If the 
 
 [Importing](#import-json--variables) these tokens recreates the composed color variable in Figma: `components` becomes the alias, `alpha` the opacity (a plain percentage or an alias to the number variable). References to variables in other collections are resolved once every collection has been imported.
 
+> [!WARNING]
+> Some Figma clients can read these variables but refuse to write them ("Composed color variable values are not supported"), currently including Figma Desktop. The plugin then leaves those values untouched, reports how many were skipped and links to [figma/plugin-typings#375](https://github.com/figma/plugin-typings/issues/375). Other tokens in the same import are not affected.
+
 > [!NOTE]
 > This shape is an extension of the DTCG format, so a consumer needs a small custom transform: resolve the `components` reference, then apply `alpha`.
 

--- a/README.md
+++ b/README.md
@@ -1057,7 +1057,12 @@ The [DTCG color type](https://www.designtokens.org/tr/2025.10/color/#format) has
   "color": {
     "brand": {
       "$type": "color",
-      "$value": { "colorSpace": "srgb", "components": [0.2, 0.4, 0.8], "alpha": 1, "hex": "#3366cc" }
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.2, 0.4, 0.8],
+        "alpha": 1,
+        "hex": "#3366cc"
+      }
     },
     "brand-translucent": {
       "$type": "color",
@@ -1071,10 +1076,12 @@ The [DTCG color type](https://www.designtokens.org/tr/2025.10/color/#format) has
 }
 ```
 
-The `alpha` replaces the alpha channel of the referenced color. If the base color is a literal rather than an alias, the opacity is baked into the regular color value for the chosen [color mode](#color-mode); only when the opacity itself is a reference does the color value keep an `alpha` (or `a`) reference in place of the number.
+The `alpha` is the opacity Figma applies on top of the referenced color. If the base color is a literal rather than an alias, the opacity is baked into the regular color value for the chosen [color mode](#color-mode); only when the opacity itself is a reference does the color value keep an `alpha` (or `a`) reference in place of the number.
+
+[Importing](#import-json--variables) these tokens recreates the composed color variable in Figma: `components` becomes the alias, `alpha` the opacity (a plain percentage or an alias to the number variable). References to variables in other collections are resolved once every collection has been imported.
 
 > [!NOTE]
-> This shape is an extension of the DTCG format, so a consumer needs a small custom transform: resolve the `components` reference, then apply `alpha`. Figma's Plugin API can read these variables but not write them yet, so they cannot be imported back through the plugin.
+> This shape is an extension of the DTCG format, so a consumer needs a small custom transform: resolve the `components` reference, then apply `alpha`.
 
 ---
 
@@ -1114,16 +1121,16 @@ It follows the same pattern as used by [Cobalt](https://cobalt-ui.pages.dev/guid
 
 Unlike design tokens, Figma variables [support only 6 types](https://www.figma.com/plugin-docs/api/VariableResolvedDataType) — `COLOR`, `BOOLEAN`, `FLOAT`, `STRING`, `TIMING` and `EASING`. So, the plugin converts them into the corresponding types from the [DTCG 2025.10 specification](https://www.designtokens.org/tr/2025.10/format/#types).
 
-| Figma type | Scope condition          | Design Tokens type                                                           |
-| ---------- | ------------------------ | ---------------------------------------------------------------------------- |
-| COLOR      | —                        | [color](https://www.designtokens.org/tr/2025.10/format/#color)               |
-| BOOLEAN    | —                        | _boolean_ \*                                                                 |
-| FLOAT      | `FONT_WEIGHT` scope      | [fontWeight](https://www.designtokens.org/tr/2025.10/format/#font-weight) \* |
-| FLOAT      | `OPACITY` scope (no %)   | _number_ \*                                                                  |
-| FLOAT      | `OPACITY` scope (with %) | _string_ (e.g. `"10%"`) \*                                                   |
-| FLOAT      | all other scopes         | [dimension](https://www.designtokens.org/tr/2025.10/format/#dimension) \*\*  |
-| STRING     | —                        | _string_ \*                                                                  |
-| TIMING     | —                        | [duration](https://www.designtokens.org/tr/2025.10/format/#duration) \*\*\*   |
+| Figma type | Scope condition          | Design Tokens type                                                                               |
+| ---------- | ------------------------ | ------------------------------------------------------------------------------------------------ |
+| COLOR      | —                        | [color](https://www.designtokens.org/tr/2025.10/format/#color)                                   |
+| BOOLEAN    | —                        | _boolean_ \*                                                                                     |
+| FLOAT      | `FONT_WEIGHT` scope      | [fontWeight](https://www.designtokens.org/tr/2025.10/format/#font-weight) \*                     |
+| FLOAT      | `OPACITY` scope (no %)   | _number_ \*                                                                                      |
+| FLOAT      | `OPACITY` scope (with %) | _string_ (e.g. `"10%"`) \*                                                                       |
+| FLOAT      | all other scopes         | [dimension](https://www.designtokens.org/tr/2025.10/format/#dimension) \*\*                      |
+| STRING     | —                        | _string_ \*                                                                                      |
+| TIMING     | —                        | [duration](https://www.designtokens.org/tr/2025.10/format/#duration) \*\*\*                      |
 | EASING     | —                        | [cubicBezier](https://www.designtokens.org/tr/2025.10/format/#cubic-bezier) or _string_ \*\*\*\* |
 
 \* native JSON types — not part of the closed DTCG 2025.10 type set. With the [DTCG 2025.10 format](#dtcg-202510-format) setting on, `$type` is omitted for `string`/`boolean` tokens and the original Figma type is preserved under `$extensions.figmaType`. Also see [this issue](https://github.com/design-tokens/community-group/issues/120#issuecomment-1279527414).
@@ -1140,14 +1147,14 @@ Unlike design tokens, Figma variables [support only 6 types](https://www.figma.c
 
 Figma's `EASING` variables hold either a custom curve or one of Figma's presets. The API returns numbers only for the two custom types — every preset arrives as just a name — so the plugin maps them like this:
 
-| Figma easing                                                                         | Token type            | Example value              |
-| ------------------------------------------------------------------------------------ | --------------------- | -------------------------- |
-| Custom bezier                                                                          | `cubicBezier`         | `[0, 0, 0.58, 1]`          |
-| Linear, Ease in / out / in and out, Ease in / out / in and out back                    | `cubicBezier`         | `[0.41, 0, 1, 1]`          |
-| Linear, Ease in / out / in and out, Ease in / out / in and out back — expansion off    | `string`              | `"ease-in"`                |
-| Gentle, Quick, Bouncy, Slow                                                            | `string`              | `"gentle"`                 |
-| Custom spring                                                                          | `string`              | `"spring(bounce 0.35)"`    |
-| Hold                                                                                   | `string`              | `"hold"`                   |
+| Figma easing                                                                        | Token type    | Example value           |
+| ----------------------------------------------------------------------------------- | ------------- | ----------------------- |
+| Custom bezier                                                                       | `cubicBezier` | `[0, 0, 0.58, 1]`       |
+| Linear, Ease in / out / in and out, Ease in / out / in and out back                 | `cubicBezier` | `[0.41, 0, 1, 1]`       |
+| Linear, Ease in / out / in and out, Ease in / out / in and out back — expansion off | `string`      | `"ease-in"`             |
+| Gentle, Quick, Bouncy, Slow                                                         | `string`      | `"gentle"`              |
+| Custom spring                                                                       | `string`      | `"spring(bounce 0.35)"` |
+| Hold                                                                                | `string`      | `"hold"`                |
 
 Named bezier presets are expanded into curves unless [Expand easing presets to cubic-bezier](#expand-easing-presets-to-cubic-bezier) is turned off. Springs and Hold are always names: DTCG has no spring type, and Figma exposes no numbers for them.
 

--- a/examples/tokens-snapshot.json
+++ b/examples/tokens-snapshot.json
@@ -6,7 +6,7 @@
       "name": "Primitives",
       "defaultModeId": "1:0",
       "modes": [{ "modeId": "1:0", "name": "Value" }],
-      "variableIds": ["VariableID:1:2", "VariableID:1:3"]
+      "variableIds": ["VariableID:1:2", "VariableID:1:3", "VariableID:1:4"]
     },
     {
       "id": "VariableCollectionId:2:1",
@@ -16,7 +16,7 @@
         { "modeId": "2:0", "name": "Light" },
         { "modeId": "2:1", "name": "Dark" }
       ],
-      "variableIds": ["VariableID:2:2"]
+      "variableIds": ["VariableID:2:2", "VariableID:2:3"]
     }
   ],
   "variables": [
@@ -43,6 +43,18 @@
       }
     },
     {
+      "id": "VariableID:1:4",
+      "name": "opacity/50",
+      "variableCollectionId": "VariableCollectionId:1:1",
+      "resolvedType": "FLOAT",
+      "description": "Opacity for color variables",
+      "scopes": ["COLOR_OPACITY"],
+      "remote": false,
+      "valuesByMode": {
+        "1:0": 50
+      }
+    },
+    {
       "id": "VariableID:2:2",
       "name": "surface/accent",
       "variableCollectionId": "VariableCollectionId:2:1",
@@ -51,6 +63,29 @@
       "valuesByMode": {
         "2:0": { "type": "VARIABLE_ALIAS", "id": "VariableID:1:2" },
         "2:1": { "r": 0.4, "g": 0.6, "b": 1, "a": 1 }
+      }
+    },
+    {
+      "id": "VariableID:2:3",
+      "name": "surface/accent-muted",
+      "variableCollectionId": "VariableCollectionId:2:1",
+      "resolvedType": "COLOR",
+      "description": "Blue primitive with an opacity applied on top",
+      "remote": false,
+      "valuesByMode": {
+        "2:0": {
+          "type": "VARIABLE_EXPRESSION",
+          "expressionFunction": "COMPOSE_COLOR",
+          "expressionArguments": [{ "type": "VARIABLE_ALIAS", "id": "VariableID:1:2" }, 50]
+        },
+        "2:1": {
+          "type": "VARIABLE_EXPRESSION",
+          "expressionFunction": "COMPOSE_COLOR",
+          "expressionArguments": [
+            { "type": "VARIABLE_ALIAS", "id": "VariableID:1:2" },
+            { "type": "VARIABLE_ALIAS", "id": "VariableID:1:4" }
+          ]
+        }
       }
     }
   ],

--- a/global.d.ts
+++ b/global.d.ts
@@ -168,6 +168,7 @@ interface TokensMessageI {
     success: boolean;
     message: string;
     collectionsCreated: number;
+    composedColorsRejected?: number;
     variablesCreated: number;
     errors: string[];
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokens-bruecke",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokens-bruecke",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/schemas/tokens-snapshot.schema.json
+++ b/schemas/tokens-snapshot.schema.json
@@ -129,6 +129,7 @@
       "description": "A resolved variable value, or an alias pointing at another variable.",
       "oneOf": [
         { "$ref": "#/definitions/variableAlias" },
+        { "$ref": "#/definitions/composedColor" },
         { "$ref": "#/definitions/rgba" },
         { "type": "number" },
         { "type": "string" },
@@ -142,6 +143,34 @@
       "properties": {
         "type": { "const": "VARIABLE_ALIAS" },
         "id": { "type": "string" }
+      }
+    },
+    "composedColor": {
+      "type": "object",
+      "description": "A color variable that aliases another color and applies its own opacity on top (Figma \"Control opacity at scale\", September 2026), as the Plugin API returns it. The first argument is the base color (alias or rgba), the second the opacity in percent (0..100) or an alias to a number variable. Exports as `{ components: \"{color.brand}\", alpha: 0.5 }` — see README, \"Color aliases with opacity\".",
+      "required": ["type", "expressionFunction", "expressionArguments"],
+      "properties": {
+        "type": { "const": "VARIABLE_EXPRESSION" },
+        "expressionFunction": { "const": "COMPOSE_COLOR" },
+        "expressionArguments": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "oneOf": [
+                { "$ref": "#/definitions/variableAlias" },
+                { "$ref": "#/definitions/rgba" }
+              ]
+            },
+            {
+              "oneOf": [
+                { "$ref": "#/definitions/variableAlias" },
+                { "type": "number", "minimum": 0, "maximum": 100 }
+              ]
+            }
+          ]
+        }
       }
     },
     "rgba": {

--- a/skills/tokens-bruecke/SKILL.md
+++ b/skills/tokens-bruecke/SKILL.md
@@ -143,7 +143,7 @@ Rules that matter:
 - `variables` and `variableCollections` are **required**; the four style arrays are optional and only read when the matching `includedStyles.*.isIncluded` config flag is on.
 - `valuesByMode` is keyed by **`modeId`**, not by mode name. Mode names come from the collection's `modes` array.
 - Aliases are `{ "type": "VARIABLE_ALIAS", "id": "<variable id>" }`. The target variable must be present in the snapshot, otherwise the value exports as `"#missing#"` — the same behaviour as the REST resolver. Library (remote) variables are not resolvable today; include them in `variables` if you need them aliased.
-- Color aliases with their own opacity (Figma "Control opacity at scale") are `{ "type": "VARIABLE_EXPRESSION", "expressionFunction": "COMPOSE_COLOR", "expressionArguments": [<alias or rgba>, <0..100 or alias>] }`. Pass them through verbatim; they export as `{ "components": "{path.to.color}", "alpha": 0.5 }` (or a reference in `alpha`).
+- Color aliases with their own opacity (Figma "Control opacity at scale") are `{ "type": "VARIABLE_EXPRESSION", "expressionFunction": "COMPOSE_COLOR", "expressionArguments": [<alias or rgba>, <0..100 or alias>] }`. Pass them through verbatim; they export as `{ "components": "{path.to.color}", "alpha": 0.5 }` (or a reference in `alpha`), and import back as the same expression.
 - `collection.variableIds` preserves Figma's Variables-panel ordering in the output. Without it, output order follows the `variables` array.
 - Colors are 0..1 float channels (`{ r, g, b, a }`), as the Plugin API returns them — not 0..255 and not hex.
 - Filter out remote (library) variables and collections, matching what the REST resolver does.

--- a/skills/tokens-bruecke/SKILL.md
+++ b/skills/tokens-bruecke/SKILL.md
@@ -143,6 +143,7 @@ Rules that matter:
 - `variables` and `variableCollections` are **required**; the four style arrays are optional and only read when the matching `includedStyles.*.isIncluded` config flag is on.
 - `valuesByMode` is keyed by **`modeId`**, not by mode name. Mode names come from the collection's `modes` array.
 - Aliases are `{ "type": "VARIABLE_ALIAS", "id": "<variable id>" }`. The target variable must be present in the snapshot, otherwise the value exports as `"#missing#"` — the same behaviour as the REST resolver. Library (remote) variables are not resolvable today; include them in `variables` if you need them aliased.
+- Color aliases with their own opacity (Figma "Control opacity at scale") are `{ "type": "VARIABLE_EXPRESSION", "expressionFunction": "COMPOSE_COLOR", "expressionArguments": [<alias or rgba>, <0..100 or alias>] }`. Pass them through verbatim; they export as `{ "components": "{path.to.color}", "alpha": 0.5 }` (or a reference in `alpha`).
 - `collection.variableIds` preserves Figma's Variables-panel ordering in the output. Without it, output order follows the `variables` array.
 - Colors are 0..1 float channels (`{ r, g, b, a }`), as the Plugin API returns them — not 0..255 and not hex.
 - Filter out remote (library) variables and collections, matching what the REST resolver does.

--- a/src/app/controller/index.ts
+++ b/src/app/controller/index.ts
@@ -137,6 +137,7 @@ figma.ui.onmessage = async (msg) => {
           success: false,
           message: `Import failed: ${error.message}`,
           collectionsCreated: 0,
+          composedColorsRejected: 0,
           variablesCreated: 0,
           errors: [error.message],
         },

--- a/src/app/views/SettingsView/index.tsx
+++ b/src/app/views/SettingsView/index.tsx
@@ -19,6 +19,7 @@ import {
 import { config } from '@app/controller/config';
 
 import { Toast, ToastRefI } from '@app/components/Toast';
+import { COMPOSED_COLOR_ISSUE_URL } from '@common/transform/tokensToVariables';
 import { AdvancedSettingsView } from '@app/views/AdvancedSettingsView';
 import { ServerSettingsView } from '@app/views/ServerSettingsView';
 import { ProfileDetailView } from '@app/views/ProfileDetailView';
@@ -378,12 +379,24 @@ export const SettingsView = (props: ViewProps) => {
         setIsImporting(false);
 
         if (result) {
+          const hasIssues = result.errors.length > 0;
           toastRef.current?.show({
-            title: result.success ? 'Import Successful' : 'Import Failed',
+            title: result.success
+              ? hasIssues
+                ? 'Imported with issues'
+                : 'Import Successful'
+              : 'Import Failed',
             message: result.message,
+            ...(result.composedColorsRejected > 0 && {
+              link: {
+                label: 'Figma issue #375: composed colors are read-only',
+                url: COMPOSED_COLOR_ISSUE_URL,
+              },
+            }),
             options: {
-              type: result.success ? 'success' : 'error',
-              timeout: 10000,
+              type: result.success ? (hasIssues ? 'warn' : 'success') : 'error',
+              // leave time to read the issues
+              timeout: hasIssues ? 60000 : 10000,
             },
           });
 

--- a/src/cli/fileResolver.spec.ts
+++ b/src/cli/fileResolver.spec.ts
@@ -159,6 +159,26 @@ describe('getTokens with a snapshot', () => {
     );
   });
 
+  it('exports color aliases with opacity as composed values', async () => {
+    const resolver = new FileResolver(exampleSnapshot());
+    const tokens: any = await getTokens(resolver, baseConfig);
+    const muted = tokens.Semantic.surface['accent-muted'];
+
+    expect(muted.$type).toBe('color');
+    expect(muted.$value).toEqual({
+      components: '{Primitives.colors.blue.500}',
+      alpha: 0.5,
+    });
+    expect(muted.$extensions.mode.Dark).toEqual({
+      components: '{Primitives.colors.blue.500}',
+      alpha: '{Primitives.opacity.50}',
+    });
+
+    // The number variable driving the opacity exports like an OPACITY float
+    expect(tokens.Primitives.opacity['50'].$type).toBe('number');
+    expect(tokens.Primitives.opacity['50'].$value).toBe(0.5);
+  });
+
   it('matches REST behaviour for aliases outside the snapshot', async () => {
     const orphan = {
       ...minimal,

--- a/src/common/transform/color/composeColor.ts
+++ b/src/common/transform/color/composeColor.ts
@@ -1,0 +1,115 @@
+import Decimal from 'decimal.js';
+import { convertRGBA } from './convertRGBA';
+
+/**
+ * Figma's "Control opacity at scale" release (September 2026) lets a color
+ * variable alias another color and apply its own opacity on top, optionally
+ * driven by a number variable. The Plugin API returns such values as an
+ * expression rather than a plain alias or RGBA:
+ *
+ * ```js
+ * {
+ *   type: 'VARIABLE_EXPRESSION',
+ *   expressionFunction: 'COMPOSE_COLOR',
+ *   expressionArguments: [
+ *     { type: 'VARIABLE_ALIAS', id: '…' } | { r, g, b, a },
+ *     50 | { type: 'VARIABLE_ALIAS', id: '…' },
+ *   ],
+ * }
+ * ```
+ *
+ * The first argument is the base color, the second the opacity in percent
+ * (0..100) or an alias to a FLOAT variable holding it.
+ */
+export interface ComposedColorValue {
+  type: 'VARIABLE_EXPRESSION';
+  expressionFunction: 'COMPOSE_COLOR';
+  expressionArguments: [RGBA | VariableAlias, number | VariableAlias];
+}
+
+export const isComposedColor = (value: any): value is ComposedColorValue =>
+  value?.type === 'VARIABLE_EXPRESSION' &&
+  value.expressionFunction === 'COMPOSE_COLOR' &&
+  Array.isArray(value.expressionArguments);
+
+const isAlias = (value: any): value is VariableAlias =>
+  value?.type === 'VARIABLE_ALIAS' && typeof value.id === 'string';
+
+const DTCG_COLOR_MODES: ReadonlyArray<colorModeType> = [
+  'srgb-dtcg',
+  'hsl-dtcg',
+  'oklch-dtcg',
+];
+const OBJECT_COLOR_MODES: ReadonlyArray<colorModeType> = [
+  'rgba-object',
+  'hsla-object',
+];
+
+interface PropsI {
+  value: ComposedColorValue;
+  colorMode: colorModeType;
+  usePercentageOpacity: boolean;
+  /** Turns a variable id into a `{collection.path}` reference string. */
+  resolveAlias: (variableId: string) => Promise<string>;
+}
+
+/**
+ * Converts a composed color into a token value.
+ *
+ * The DTCG color type has no way to express "this color, with that opacity"
+ * when either half is a reference, so the value is emitted as a composite
+ * object whose parts may be references (see README, "Color aliases with
+ * opacity"):
+ *
+ * - base is an alias → `{ components: "{color.brand}", alpha: 0.5 | "{opacity.50}" }`
+ * - base is a literal, opacity is a number → a regular color value with the
+ *   opacity baked in as its alpha channel
+ * - base is a literal, opacity is an alias → the regular color value for the
+ *   chosen color mode, with its alpha replaced by the reference
+ */
+export const normalizeComposedColor = async ({
+  value,
+  colorMode,
+  usePercentageOpacity,
+  resolveAlias,
+}: PropsI) => {
+  const [baseColor, opacity] = value.expressionArguments;
+
+  const alpha = isAlias(opacity)
+    ? await resolveAlias(opacity.id)
+    : normalizeOpacity(opacity, usePercentageOpacity);
+
+  if (isAlias(baseColor)) {
+    return { components: await resolveAlias(baseColor.id), alpha };
+  }
+
+  if (!isAlias(opacity)) {
+    // Both halves are literal — Figma's opacity replaces the base alpha.
+    return convertRGBA(
+      { ...baseColor, a: new Decimal(opacity).div(100).toNumber() },
+      colorMode
+    );
+  }
+
+  const opaqueBase = convertRGBA({ ...baseColor, a: 1 }, colorMode);
+
+  if (DTCG_COLOR_MODES.includes(colorMode)) {
+    return { ...(opaqueBase as object), alpha };
+  }
+  if (OBJECT_COLOR_MODES.includes(colorMode)) {
+    return { ...(opaqueBase as object), a: alpha };
+  }
+  return { components: opaqueBase, alpha };
+};
+
+/**
+ * Figma stores the opacity as 0..100 percent; tokens use a 0..1 fraction
+ * unless percentage opacity output is enabled (matching FLOAT opacity
+ * variables).
+ */
+const normalizeOpacity = (opacity: number, usePercentageOpacity: boolean) => {
+  if (usePercentageOpacity) {
+    return `${opacity}%`;
+  }
+  return new Decimal(opacity).div(100).toNumber();
+};

--- a/src/common/transform/motion.spec.ts
+++ b/src/common/transform/motion.spec.ts
@@ -195,3 +195,53 @@ describe('round trip', () => {
     expect(parseDurationToSeconds(exported)).toBe(0.3);
   });
 });
+
+describe('easing presets with the curve attached by Figma', () => {
+  test('the attached curve wins over the table when expanding', () => {
+    expect(
+      normalizeEasing(
+        {
+          type: 'EASE_IN',
+          easingFunctionCubicBezier: { x1: 0.42, y1: 0, x2: 1, y2: 1 },
+        },
+        true
+      )
+    ).toEqual({ type: 'cubicBezier', value: [0.42, 0, 1, 1] });
+  });
+
+  test('the attached curve is ignored when presets are not expanded', () => {
+    expect(
+      normalizeEasing(
+        {
+          type: 'EASE_IN',
+          easingFunctionCubicBezier: { x1: 0.42, y1: 0, x2: 1, y2: 1 },
+        },
+        false
+      )
+    ).toEqual({ type: 'string', value: 'ease-in' });
+  });
+
+  test('spring presets keep their name even with a bounce attached', () => {
+    expect(
+      normalizeEasing(
+        { type: 'GENTLE', easingFunctionSpring: { bounce: 0.25 } },
+        true
+      )
+    ).toEqual({ type: 'string', value: 'gentle' });
+  });
+
+  test('curves from older exports still map back to the preset', () => {
+    expect(parseEasing([0.41, 0, 1, 1])).toEqual({ type: 'EASE_IN' });
+    expect(parseEasing([0, 0, 0.59, 1])).toEqual({ type: 'EASE_OUT' });
+    expect(parseEasing([0.41, 0, 0.59, 1])).toEqual({
+      type: 'EASE_IN_AND_OUT',
+    });
+  });
+
+  test('a curve clearly off a preset stays custom', () => {
+    expect(parseEasing([0.5, 0, 1, 1])).toEqual({
+      type: 'CUSTOM_CUBIC_BEZIER',
+      easingFunctionCubicBezier: { x1: 0.5, y1: 0, x2: 1, y2: 1 },
+    });
+  });
+});

--- a/src/common/transform/motion.ts
+++ b/src/common/transform/motion.ts
@@ -10,23 +10,18 @@ export type CubicBezierValueI = [number, number, number, number];
 type MotionEasingType = MotionEasing['type'];
 
 /**
- * Cubic-bezier equivalents of Figma's named easing presets.
- *
- * Figma's API only returns numbers for `CUSTOM_CUBIC_BEZIER` — named presets
- * arrive as `{ type: 'EASE_IN' }` with no curve attached, and Figma does not
- * publish their control points. To read a preset's real values, set an easing
- * variable to that preset in Figma and switch it to "Custom bezier".
- *
- * `LINEAR` is exact. The rest are community-sourced; the `*_BACK` entries in
- * particular are the least confirmed.
+ * Cubic-bezier equivalents of Figma's named easing presets, as returned by
+ * the Plugin API (`easingFunctionCubicBezier` on a preset value, verified
+ * September 2026). Used when a preset arrives without its curve attached, and
+ * to map an expanded curve back to its preset on import.
  */
 export const EASING_PRESET_BEZIERS: Partial<
   Record<MotionEasingType, CubicBezierValueI>
 > = {
   LINEAR: [0, 0, 1, 1],
-  EASE_IN: [0.41, 0, 1, 1],
-  EASE_OUT: [0, 0, 0.59, 1],
-  EASE_IN_AND_OUT: [0.41, 0, 0.59, 1],
+  EASE_IN: [0.42, 0, 1, 1],
+  EASE_OUT: [0, 0, 0.58, 1],
+  EASE_IN_AND_OUT: [0.42, 0, 0.58, 1],
   EASE_IN_BACK: [0.3, -0.05, 0.7, -0.5],
   EASE_OUT_BACK: [0.45, 1.45, 0.8, 1],
   EASE_IN_AND_OUT_BACK: [0.7, -0.4, 0.4, 1.4],
@@ -62,6 +57,9 @@ const CUSTOM_SPRING_PATTERN = /^spring\(\s*bounce\s+(-?\d*\.?\d+)\s*\)$/i;
 // without touching any value a designer could have entered.
 const DURATION_DECIMALS = 3;
 const BEZIER_DECIMALS = 6;
+// How far a control point may drift from the table when matching an exported
+// curve back to a preset (float noise, older exports of a preset).
+const BEZIER_TOLERANCE = 0.02;
 
 const round = (value: number, decimals: number): number =>
   new Decimal(value).toDecimalPlaces(decimals).toNumber();
@@ -104,13 +102,23 @@ export const normalizeEasing = (
     return { type: 'string', value: String(easing) };
   }
 
-  if (easing.type === 'CUSTOM_CUBIC_BEZIER' && easing.easingFunctionCubicBezier) {
-    const { x1, y1, x2, y2 } = easing.easingFunctionCubicBezier;
+  const toCurve = (bezier: {
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+  }): CubicBezierValueI =>
+    [bezier.x1, bezier.y1, bezier.x2, bezier.y2].map((point) =>
+      round(point, BEZIER_DECIMALS)
+    ) as CubicBezierValueI;
+
+  if (
+    easing.type === 'CUSTOM_CUBIC_BEZIER' &&
+    easing.easingFunctionCubicBezier
+  ) {
     return {
       type: 'cubicBezier',
-      value: [x1, y1, x2, y2].map((point) =>
-        round(point, BEZIER_DECIMALS)
-      ) as CubicBezierValueI,
+      value: toCurve(easing.easingFunctionCubicBezier),
     };
   }
 
@@ -127,7 +135,13 @@ export const normalizeEasing = (
 
   const presetBezier = EASING_PRESET_BEZIERS[easing.type];
   if (expandEasingPresets && presetBezier) {
-    return { type: 'cubicBezier', value: presetBezier };
+    // Prefer the curve Figma attaches to the preset over the table
+    return {
+      type: 'cubicBezier',
+      value: easing.easingFunctionCubicBezier
+        ? toCurve(easing.easingFunctionCubicBezier)
+        : presetBezier,
+    };
   }
 
   return {
@@ -184,7 +198,9 @@ export const parseEasing = (value: any): MotionEasing => {
     const preset = (
       Object.keys(EASING_PRESET_BEZIERS) as MotionEasingType[]
     ).find((type) =>
-      EASING_PRESET_BEZIERS[type].every((point, index) => point === value[index])
+      EASING_PRESET_BEZIERS[type].every(
+        (point, index) => Math.abs(point - value[index]) <= BEZIER_TOLERANCE
+      )
     );
     if (preset) {
       return { type: preset };

--- a/src/common/transform/normalizeType.spec.ts
+++ b/src/common/transform/normalizeType.spec.ts
@@ -10,3 +10,25 @@ describe('getFontStyleAndWeight', () => {
     expect(normalizeType('FLOAT', ['FONT_WEIGHT'])).toBe('fontWeight');
   });
 });
+
+describe('opacity scopes', () => {
+  test('OPACITY', () => {
+    expect(normalizeType('FLOAT', ['OPACITY'])).toBe('number');
+    expect(normalizeType('FLOAT', ['OPACITY'], true)).toBe('string');
+  });
+  test('COLOR_OPACITY (opacity of a color variable)', () => {
+    expect(normalizeType('FLOAT', ['COLOR_OPACITY' as VariableScope])).toBe(
+      'number'
+    );
+    expect(
+      normalizeType(
+        'FLOAT',
+        ['OPACITY', 'COLOR_OPACITY' as VariableScope],
+        true
+      )
+    ).toBe('string');
+  });
+  test('mixed with other scopes stays a dimension', () => {
+    expect(normalizeType('FLOAT', ['OPACITY', 'GAP'])).toBe('dimension');
+  });
+});

--- a/src/common/transform/normalizeType.ts
+++ b/src/common/transform/normalizeType.ts
@@ -1,4 +1,5 @@
 import { normalizeEasing } from './motion';
+import { isOpacityScope } from './opacityScopes';
 
 export const normalizeType = (
   type: VariableResolvedDataType,
@@ -13,12 +14,11 @@ export const normalizeType = (
     case 'COLOR':
       return 'color';
     case 'FLOAT':
-      if (variableScopes.length === 1) {
-        if (variableScopes[0] === 'FONT_WEIGHT') {
-          return 'fontWeight';
-        } else if (variableScopes[0] === 'OPACITY') {
-          return usePercentageOpacity ? 'string' : 'number';
-        }
+      if (variableScopes.length === 1 && variableScopes[0] === 'FONT_WEIGHT') {
+        return 'fontWeight';
+      }
+      if (isOpacityScope(variableScopes)) {
+        return usePercentageOpacity ? 'string' : 'number';
       }
       return 'dimension';
     case 'STRING':

--- a/src/common/transform/normalizeValue.spec.ts
+++ b/src/common/transform/normalizeValue.spec.ts
@@ -215,3 +215,158 @@ describe('getColor', () => {
     });
   });
 });
+
+describe('composed colors (color alias with opacity)', () => {
+  const variables: Record<string, Partial<Variable>> = {
+    'VariableID:1': {
+      id: 'VariableID:1',
+      name: 'brand/blue',
+      variableCollectionId: 'C:1',
+    },
+    'VariableID:2': {
+      id: 'VariableID:2',
+      name: 'opacity/50',
+      variableCollectionId: 'C:1',
+    },
+  };
+  const aliasResolver = {
+    getVariableById: async (id: string) => (variables[id] ?? null) as Variable,
+    getVariableCollectionById: async () =>
+      ({ id: 'C:1', name: 'Primitives' } as VariableCollection),
+  } as unknown as IResolver;
+
+  const compose = (base: any, opacity: any) => ({
+    type: 'VARIABLE_EXPRESSION',
+    expressionFunction: 'COMPOSE_COLOR',
+    expressionArguments: [base, opacity],
+  });
+  const blueAlias = { type: 'VARIABLE_ALIAS', id: 'VariableID:1' };
+  const opacityAlias = { type: 'VARIABLE_ALIAS', id: 'VariableID:2' };
+  const red = { r: 1, g: 0, b: 0, a: 1 };
+
+  const normalize = (
+    variableValue: any,
+    overrides: Partial<Parameters<typeof normalizeValue>[0]> = {}
+  ) =>
+    normalizeValue(
+      {
+        variableValue,
+        variableType: 'COLOR',
+        variableScope: ['ALL_SCOPES'],
+        colorMode: 'hex',
+        useDTCG: true,
+        includeValueStringKeyToAlias: false,
+        usePercentageOpacity: false,
+        ...overrides,
+      },
+      aliasResolver
+    );
+
+  test('alias base with a literal opacity', async () => {
+    expect(await normalize(compose(blueAlias, 50))).toStrictEqual({
+      components: '{Primitives.brand.blue}',
+      alpha: 0.5,
+    });
+  });
+
+  test('alias base with an aliased opacity', async () => {
+    expect(await normalize(compose(blueAlias, opacityAlias))).toStrictEqual({
+      components: '{Primitives.brand.blue}',
+      alpha: '{Primitives.opacity.50}',
+    });
+  });
+
+  test('respects the percentage opacity setting', async () => {
+    expect(
+      await normalize(compose(blueAlias, 33.3), { usePercentageOpacity: true })
+    ).toStrictEqual({
+      components: '{Primitives.brand.blue}',
+      alpha: '33.3%',
+    });
+  });
+
+  test('respects the .value alias suffix and omitted collection names', async () => {
+    expect(
+      await normalize(compose(blueAlias, opacityAlias), {
+        includeValueStringKeyToAlias: true,
+        omitCollectionNames: true,
+      })
+    ).toStrictEqual({
+      components: '{brand.blue.$value}',
+      alpha: '{opacity.50.$value}',
+    });
+  });
+
+  test('unresolvable alias base falls back to the missing marker', async () => {
+    expect(
+      await normalize(
+        compose({ type: 'VARIABLE_ALIAS', id: 'VariableID:404' }, 50)
+      )
+    ).toStrictEqual({ components: '#missing#', alpha: 0.5 });
+  });
+
+  test('literal base with a literal opacity bakes the alpha in', async () => {
+    expect(await normalize(compose(red, 50))).toBe('#ff000080');
+    expect(
+      await normalize(compose(red, 50), { colorMode: 'srgb-dtcg' })
+    ).toStrictEqual({
+      colorSpace: 'srgb',
+      components: [1, 0, 0],
+      alpha: 0.5,
+      hex: '#ff000080',
+    });
+  });
+
+  test('literal base with an aliased opacity, DTCG color mode', async () => {
+    expect(
+      await normalize(compose(red, opacityAlias), { colorMode: 'srgb-dtcg' })
+    ).toStrictEqual({
+      colorSpace: 'srgb',
+      components: [1, 0, 0],
+      alpha: '{Primitives.opacity.50}',
+      hex: '#ff0000',
+    });
+  });
+
+  test('literal base with an aliased opacity, object color mode', async () => {
+    expect(
+      await normalize(compose(red, opacityAlias), { colorMode: 'rgba-object' })
+    ).toStrictEqual({ r: 255, g: 0, b: 0, a: '{Primitives.opacity.50}' });
+  });
+
+  test('literal base with an aliased opacity, string color mode', async () => {
+    expect(
+      await normalize(compose(red, opacityAlias), { colorMode: 'rgba-css' })
+    ).toStrictEqual({
+      components: 'rgb(255, 0, 0)',
+      alpha: '{Primitives.opacity.50}',
+    });
+  });
+});
+
+describe('opacity scopes', () => {
+  test('COLOR_OPACITY floats export like OPACITY floats', async () => {
+    const props = {
+      variableValue: 50,
+      variableType: 'FLOAT' as const,
+      variableScope: ['COLOR_OPACITY' as VariableScope],
+      colorMode: 'hex' as const,
+      useDTCG: true,
+      includeValueStringKeyToAlias: false,
+      usePercentageOpacity: false,
+    };
+    expect(await normalizeValue(props, resolver)).toBe(0.5);
+    expect(
+      await normalizeValue({ ...props, usePercentageOpacity: true }, resolver)
+    ).toBe('50%');
+    expect(
+      await normalizeValue(
+        {
+          ...props,
+          variableScope: ['OPACITY', 'COLOR_OPACITY' as VariableScope],
+        },
+        resolver
+      )
+    ).toBe(0.5);
+  });
+});

--- a/src/common/transform/normalizeValue.ts
+++ b/src/common/transform/normalizeValue.ts
@@ -1,6 +1,8 @@
 import Decimal from 'decimal.js';
 import { IResolver } from '@common/resolver';
 import { convertRGBA } from './color/convertRGBA';
+import { isComposedColor, normalizeComposedColor } from './color/composeColor';
+import { isOpacityScope } from './opacityScopes';
 import { getAliasVariableName } from './getAliasVariableName';
 import { makeDimension } from './makeDimension';
 import { makeDuration, normalizeEasing } from './motion';
@@ -46,6 +48,23 @@ export const normalizeValue = async (props: PropsI, resolver: IResolver) => {
     return aliasVariableName;
   }
 
+  if (isComposedColor(variableValue)) {
+    // Color alias with its own opacity (Figma "Control opacity at scale")
+    return normalizeComposedColor({
+      value: variableValue,
+      colorMode,
+      usePercentageOpacity,
+      resolveAlias: (id) =>
+        getAliasVariableName(
+          id,
+          useDTCG,
+          includeValueStringKeyToAlias,
+          resolver,
+          omitCollectionNames
+        ),
+    });
+  }
+
   if (variableType === 'COLOR') {
     return convertRGBA(variableValue, colorMode);
   }
@@ -53,7 +72,7 @@ export const normalizeValue = async (props: PropsI, resolver: IResolver) => {
   if (variableType === 'FLOAT') {
     if (variableScope.length === 1 && variableScope[0] === 'FONT_WEIGHT') {
       return Number(variableValue);
-    } else if (variableScope.length === 1 && variableScope[0] === 'OPACITY') {
+    } else if (isOpacityScope(variableScope)) {
       if (usePercentageOpacity) {
         return `${variableValue}%`;
       } else {

--- a/src/common/transform/opacityScopes.ts
+++ b/src/common/transform/opacityScopes.ts
@@ -1,0 +1,20 @@
+/**
+ * Scopes that mark a FLOAT variable as an opacity (0..100 percent) rather
+ * than a dimension.
+ *
+ * `COLOR_OPACITY` was introduced with Figma's "Control opacity at scale"
+ * release (September 2026): a number variable with this scope can drive the
+ * opacity of a color variable. It is not part of the published
+ * `VariableScope` typings yet, hence the plain-string list.
+ */
+export const OPACITY_SCOPES: ReadonlyArray<string> = [
+  'OPACITY',
+  'COLOR_OPACITY',
+];
+
+export const isOpacityScope = (
+  scopes: ReadonlyArray<string> | undefined
+): boolean =>
+  Array.isArray(scopes) &&
+  scopes.length > 0 &&
+  scopes.every((scope) => OPACITY_SCOPES.includes(scope));

--- a/src/common/transform/tokensToVariables.import.spec.ts
+++ b/src/common/transform/tokensToVariables.import.spec.ts
@@ -212,6 +212,49 @@ describe('tokensToVariables with composed colors', () => {
     expect(valueOf('broken')).toBeUndefined();
   });
 
+  test('imports motion tokens as TIMING and EASING variables', async () => {
+    const result = await tokensToVariables(
+      {
+        motion: {
+          duration: {
+            $type: 'duration',
+            $value: { value: 300, unit: 'ms' },
+            scopes: ['ALL_SCOPES'],
+          },
+          expanded: { $type: 'cubicBezier', $value: [0.42, 0, 1, 1] },
+          named: {
+            $type: 'string',
+            $value: 'ease-in',
+            $extensions: { figmaType: 'EASING' },
+          },
+          spring: {
+            $type: 'string',
+            $value: 'spring(bounce 0.35)',
+            scopes: ['ALL_SCOPES'],
+            $extensions: { figmaType: 'EASING' },
+          },
+          label: { $type: 'string', $value: 'hold' },
+        },
+      },
+      resolver
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(byName('duration').resolvedType).toBe('TIMING');
+    expect(byName('duration').scopes).toEqual(['ALL_SCOPES']); // untouched default
+    expect(valueOf('duration')).toBe(0.3);
+    expect(byName('expanded').resolvedType).toBe('EASING');
+    expect(valueOf('expanded')).toEqual({ type: 'EASE_IN' });
+    expect(valueOf('named')).toEqual({ type: 'EASE_IN' });
+    expect(valueOf('spring')).toEqual({
+      type: 'CUSTOM_SPRING',
+      easingFunctionSpring: { bounce: 0.35 },
+    });
+    // Without the marker a plain string stays a string variable
+    expect(byName('label').resolvedType).toBe('STRING');
+    expect(valueOf('label')).toBe('hold');
+  });
+
   test('keeps the variable when the runtime rejects a scope', async () => {
     const original = fake.variables.createVariable;
     fake.variables.createVariable = (...args: any[]) => {

--- a/src/common/transform/tokensToVariables.import.spec.ts
+++ b/src/common/transform/tokensToVariables.import.spec.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { IResolver } from '@common/resolver';
+import { tokensToVariables } from './tokensToVariables';
+
+/**
+ * Minimal in-memory stand-in for the parts of the Figma Plugin API the
+ * import touches, so the multi-pass import can run under vitest.
+ */
+const createFakeFigma = () => {
+  const collections: any[] = [];
+  const variables: any[] = [];
+  let nextId = 1;
+
+  const createVariableCollection = (name: string) => {
+    const collection = {
+      id: `VariableCollectionId:${nextId++}`,
+      name,
+      modes: [{ modeId: `${nextId++}:0`, name: 'Mode 1' }],
+      variableIds: [] as string[],
+      get defaultModeId() {
+        return this.modes[0].modeId;
+      },
+      renameMode(modeId: string, newName: string) {
+        this.modes.find((m: any) => m.modeId === modeId).name = newName;
+      },
+      addMode(name: string) {
+        this.modes.push({ modeId: `${nextId++}:0`, name });
+      },
+    };
+    collections.push(collection);
+    return collection;
+  };
+
+  const createVariable = (name: string, collection: any, type: string) => {
+    const variable = {
+      id: `VariableID:${nextId++}`,
+      name,
+      variableCollectionId: collection.id,
+      resolvedType: type,
+      valuesByMode: {} as Record<string, any>,
+      scopes: ['ALL_SCOPES'],
+      description: '',
+      setValueForMode(modeId: string, value: any) {
+        if (
+          typeof value === 'string' &&
+          value.startsWith('{') &&
+          value.endsWith('}')
+        ) {
+          throw new Error('Expected a value, received an unresolved reference');
+        }
+        this.valuesByMode[modeId] = value;
+      },
+    };
+    collection.variableIds.push(variable.id);
+    variables.push(variable);
+    return variable;
+  };
+
+  return {
+    variables: {
+      createVariableCollection,
+      createVariable,
+      getVariableCollectionByIdAsync: async (id: string) =>
+        collections.find((c) => c.id === id) ?? null,
+    },
+    _collections: collections,
+    _variables: variables,
+  };
+};
+
+const resolver = {
+  getLocalVariableCollections: async () => [],
+  getLocalVariables: async () => [],
+} as unknown as IResolver;
+
+const composed = (base: any, opacity: any) => ({
+  type: 'VARIABLE_EXPRESSION',
+  expressionFunction: 'COMPOSE_COLOR',
+  expressionArguments: [base, opacity],
+});
+
+describe('tokensToVariables with composed colors', () => {
+  let fake: ReturnType<typeof createFakeFigma>;
+
+  beforeEach(() => {
+    fake = createFakeFigma();
+    vi.stubGlobal('figma', fake);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const byName = (name: string) => fake._variables.find((v) => v.name === name);
+  const modeOf = (variable: any, modeName = 'Mode 1') =>
+    fake._collections
+      .find((c) => c.id === variable.variableCollectionId)
+      .modes.find((m: any) => m.name === modeName).modeId;
+  const valueOf = (name: string, modeName?: string) => {
+    const variable = byName(name);
+    return variable.valuesByMode[modeOf(variable, modeName)];
+  };
+
+  test('writes composed colors back as COMPOSE_COLOR expressions', async () => {
+    const result = await tokensToVariables(
+      {
+        t1: {
+          color: {
+            black: { $type: 'color', $value: '#000000' },
+            translucent: {
+              $type: 'color',
+              $value: {
+                components: '{t1.color.black}',
+                alpha: '{t1.opacity.0}',
+              },
+            },
+            half: {
+              $type: 'color',
+              $value: { components: '{t1.color.black}', alpha: 0.5 },
+            },
+            literal: {
+              $type: 'color',
+              $value: {
+                colorSpace: 'srgb',
+                components: [1, 0, 0],
+                alpha: '{t1.opacity.0}',
+                hex: '#ff0000',
+              },
+            },
+          },
+          opacity: {
+            '0': { $type: 'number', $value: 0, scopes: ['COLOR_OPACITY'] },
+          },
+        },
+      },
+      resolver
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.variablesCreated).toBe(5);
+
+    const black = byName('color/black');
+    const opacity = byName('opacity/0');
+    const alias = (variable: any) => ({
+      type: 'VARIABLE_ALIAS',
+      id: variable.id,
+    });
+
+    expect(opacity.scopes).toEqual(['COLOR_OPACITY']);
+    expect(valueOf('color/translucent')).toEqual(
+      composed(alias(black), alias(opacity))
+    );
+    expect(valueOf('color/half')).toEqual(composed(alias(black), 50));
+    expect(valueOf('color/literal')).toEqual(
+      composed({ r: 1, g: 0, b: 0, a: 1 }, alias(opacity))
+    );
+  });
+
+  test('resolves references to collections imported later, per mode', async () => {
+    const result = await tokensToVariables(
+      {
+        theme: {
+          surface: {
+            $type: 'color',
+            $value: { components: '{base.blue}', alpha: 0.5 },
+            $extensions: {
+              mode: {
+                Light: { components: '{base.blue}', alpha: 0.5 },
+                Dark: { components: '{base.blue}', alpha: '80%' },
+              },
+            },
+          },
+          plain: { $type: 'color', $value: '{base.blue}' },
+        },
+        base: {
+          blue: { $type: 'color', $value: '#0000ff' },
+        },
+      },
+      resolver
+    );
+
+    expect(result.errors).toEqual([]);
+
+    const blue = byName('blue');
+    const alias = { type: 'VARIABLE_ALIAS', id: blue.id };
+    expect(valueOf('surface', 'Light')).toEqual(composed(alias, 50));
+    expect(valueOf('surface', 'Dark')).toEqual(composed(alias, 80));
+    expect(valueOf('plain', 'Light')).toEqual(alias);
+  });
+
+  test('reports references that cannot be resolved at all', async () => {
+    const result = await tokensToVariables(
+      {
+        t1: {
+          broken: {
+            $type: 'color',
+            $value: { components: '{missing.color}', alpha: 0.5 },
+          },
+          brokenPlain: { $type: 'color', $value: '{missing.color}' },
+        },
+      },
+      resolver
+    );
+
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]).toMatch(
+      /Alias reference not found for "t1\/broken"/
+    );
+    expect(result.errors[1]).toMatch(
+      /Alias reference not found for "t1\/brokenPlain"/
+    );
+    expect(valueOf('broken')).toBeUndefined();
+  });
+
+  test('keeps the variable when the runtime rejects a scope', async () => {
+    const original = fake.variables.createVariable;
+    fake.variables.createVariable = (...args: any[]) => {
+      const variable = original(...(args as [any, any, any]));
+      Object.defineProperty(variable, 'scopes', {
+        set() {
+          throw new Error('Invalid enum value');
+        },
+        get() {
+          return ['ALL_SCOPES'];
+        },
+      });
+      return variable;
+    };
+
+    const result = await tokensToVariables(
+      {
+        t1: {
+          opacity: {
+            '0': { $type: 'number', $value: 0, scopes: ['COLOR_OPACITY'] },
+          },
+        },
+      },
+      resolver
+    );
+
+    expect(result.errors).toEqual([
+      'Failed to set scopes for variable "opacity/0": Invalid enum value',
+    ]);
+    expect(valueOf('opacity/0')).toBe(0);
+  });
+});

--- a/src/common/transform/tokensToVariables.import.spec.ts
+++ b/src/common/transform/tokensToVariables.import.spec.ts
@@ -212,6 +212,96 @@ describe('tokensToVariables with composed colors', () => {
     expect(valueOf('broken')).toBeUndefined();
   });
 
+  test('leaves composed colors untouched when the runtime rejects them', async () => {
+    const original = fake.variables.createVariable;
+    fake.variables.createVariable = (...args: any[]) => {
+      const variable = original(...(args as [any, any, any]));
+      const set = variable.setValueForMode.bind(variable);
+      variable.setValueForMode = (modeId: string, value: any) => {
+        if (value?.type === 'VARIABLE_EXPRESSION') {
+          throw new Error('Composed color variable values are not supported');
+        }
+        set(modeId, value);
+      };
+      return variable;
+    };
+
+    const result = await tokensToVariables(
+      {
+        theme: {
+          shadow: {
+            $type: 'color',
+            $value: { components: '{t1.gray}', alpha: '{t1.opacity4}' },
+            $extensions: {
+              mode: {
+                light: { components: '{t1.gray}', alpha: '{t1.opacity4}' },
+                dark: { components: '{t1.gray}', alpha: 0.5 },
+              },
+            },
+          },
+          plain: { $type: 'color', $value: '{t1.gray}' },
+        },
+        t1: {
+          gray: { $type: 'color', $value: '#ff0000' },
+          opacity4: { $type: 'dimension', $value: { value: 4, unit: 'px' } },
+        },
+      },
+      resolver
+    );
+
+    // nothing is written for the rejected values, other tokens are fine
+    expect(valueOf('shadow', 'light')).toBeUndefined();
+    expect(valueOf('shadow', 'dark')).toBeUndefined();
+    expect(valueOf('plain', 'light')).toEqual({
+      type: 'VARIABLE_ALIAS',
+      id: byName('gray').id,
+    });
+    // default value + light + dark
+    expect(result.composedColorsRejected).toBe(3);
+    expect(result.errors).toHaveLength(3);
+    expect(result.errors[0]).toMatch(
+      /^Skipped .*shadow.*: this Figma version cannot write color aliases with a separate opacity \(Composed color variable values are not supported\)\. See https:\/\/github\.com\/figma\/plugin-typings\/issues\/375$/
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toMatch(/3 value\(s\) skipped/);
+    expect(result.message).not.toMatch(/error\(s\)/);
+  });
+
+  test('detects composed colors that Figma drops without throwing', async () => {
+    const original = fake.variables.createVariable;
+    fake.variables.createVariable = (...args: any[]) => {
+      const variable = original(...(args as [any, any, any]));
+      const set = variable.setValueForMode.bind(variable);
+      variable.setValueForMode = (modeId: string, value: any) => {
+        if (value?.type === 'VARIABLE_EXPRESSION') {
+          return; // silently ignored
+        }
+        set(modeId, value);
+      };
+      return variable;
+    };
+
+    const result = await tokensToVariables(
+      {
+        t1: {
+          gray: { $type: 'color', $value: '#ff0000' },
+          shadow: {
+            $type: 'color',
+            $value: { components: '{t1.gray}', alpha: 0.5 },
+          },
+        },
+      },
+      resolver
+    );
+
+    expect(valueOf('shadow')).toBeUndefined();
+    expect(result.composedColorsRejected).toBe(1);
+    expect(result.errors[0]).toMatch(
+      /the value was ignored by setValueForMode/
+    );
+    expect(result.message).toMatch(/1 value\(s\) skipped/);
+  });
+
   test('imports motion tokens as TIMING and EASING variables', async () => {
     const result = await tokensToVariables(
       {

--- a/src/common/transform/tokensToVariables.spec.ts
+++ b/src/common/transform/tokensToVariables.spec.ts
@@ -5,6 +5,7 @@ import {
   isValidVariableScope,
   convertTokenValueToFigmaValue,
   isComposedColorToken,
+  hasUnresolvedReference,
   mapTokenTypeToFigmaType,
 } from './tokensToVariables';
 
@@ -346,14 +347,92 @@ describe('composed colors (color alias with opacity)', () => {
     expect(isComposedColorToken('{color.brand}')).toBe(false);
   });
 
-  test('cannot be written back through the Plugin API', () => {
-    expect(() =>
+  const variableMap = new Map<string, Variable>([
+    ['t1/color/brand', { id: 'VariableID:1:1' } as Variable],
+    ['t1/opacity/50', { id: 'VariableID:1:2' } as Variable],
+  ]);
+  const brandAlias = { type: 'VARIABLE_ALIAS', id: 'VariableID:1:1' };
+  const opacityAlias = { type: 'VARIABLE_ALIAS', id: 'VariableID:1:2' };
+
+  test('alias base with a number opacity becomes a COMPOSE_COLOR expression', () => {
+    expect(
       convertTokenValueToFigmaValue(
-        { components: '{color.brand}', alpha: 0.5 },
+        { components: '{t1.color.brand}', alpha: 0.5 },
         'color',
-        new Map()
+        variableMap
       )
-    ).toThrow(/separate opacity/);
+    ).toEqual({
+      type: 'VARIABLE_EXPRESSION',
+      expressionFunction: 'COMPOSE_COLOR',
+      expressionArguments: [brandAlias, 50],
+    });
+  });
+
+  test('percentage opacity and an aliased opacity are supported', () => {
+    expect(
+      convertTokenValueToFigmaValue(
+        { components: '{t1.color.brand}', alpha: '50%' },
+        'color',
+        variableMap
+      )
+    ).toEqual({
+      type: 'VARIABLE_EXPRESSION',
+      expressionFunction: 'COMPOSE_COLOR',
+      expressionArguments: [brandAlias, 50],
+    });
+    expect(
+      convertTokenValueToFigmaValue(
+        { components: '{t1.color.brand}', alpha: '{t1.opacity.50}' },
+        'color',
+        variableMap
+      )
+    ).toEqual({
+      type: 'VARIABLE_EXPRESSION',
+      expressionFunction: 'COMPOSE_COLOR',
+      expressionArguments: [brandAlias, opacityAlias],
+    });
+  });
+
+  test('literal base colors with an aliased opacity keep the color', () => {
+    const expected = {
+      type: 'VARIABLE_EXPRESSION',
+      expressionFunction: 'COMPOSE_COLOR',
+      expressionArguments: [{ r: 1, g: 0, b: 0, a: 1 }, opacityAlias],
+    };
+    expect(
+      convertTokenValueToFigmaValue(
+        {
+          colorSpace: 'srgb',
+          components: [1, 0, 0],
+          alpha: '{t1.opacity.50}',
+          hex: '#ff0000',
+        },
+        'color',
+        variableMap
+      )
+    ).toEqual(expected);
+    expect(
+      convertTokenValueToFigmaValue(
+        { components: '#ff0000', alpha: '{t1.opacity.50}' },
+        'color',
+        variableMap
+      )
+    ).toEqual(expected);
+  });
+
+  test('keeps the token value while a referenced variable is missing', () => {
+    const value = { components: '{t2.color.missing}', alpha: 0.5 };
+    const result = convertTokenValueToFigmaValue(value, 'color', variableMap);
+    expect(result).toBe(value);
+    expect(hasUnresolvedReference(result)).toBe(true);
+    expect(hasUnresolvedReference('{t2.color.missing}')).toBe(true);
+    expect(
+      hasUnresolvedReference({
+        type: 'VARIABLE_EXPRESSION',
+        expressionFunction: 'COMPOSE_COLOR',
+        expressionArguments: [brandAlias, 50],
+      })
+    ).toBe(false);
   });
 
   test('COLOR_OPACITY is a valid scope', () => {

--- a/src/common/transform/tokensToVariables.spec.ts
+++ b/src/common/transform/tokensToVariables.spec.ts
@@ -4,6 +4,7 @@ import {
   getTokenType,
   isValidVariableScope,
   convertTokenValueToFigmaValue,
+  isComposedColorToken,
   mapTokenTypeToFigmaType,
 } from './tokensToVariables';
 
@@ -315,5 +316,53 @@ describe('getTokenType', () => {
   test('respects explicit non-number type despite OPACITY scope', () => {
     const token = { $type: 'color', $value: '#fff', scopes: ['OPACITY'] };
     expect(getTokenType(token)).toBe('color');
+  });
+});
+
+describe('composed colors (color alias with opacity)', () => {
+  test('recognises the exported shapes', () => {
+    expect(
+      isComposedColorToken({ components: '{color.brand}', alpha: 0.5 })
+    ).toBe(true);
+    expect(
+      isComposedColorToken({
+        colorSpace: 'srgb',
+        components: [1, 0, 0],
+        alpha: '{opacity.50}',
+        hex: '#ff0000',
+      })
+    ).toBe(true);
+    expect(
+      isComposedColorToken({ r: 255, g: 0, b: 0, a: '{opacity.50}' })
+    ).toBe(true);
+    expect(
+      isComposedColorToken({
+        colorSpace: 'srgb',
+        components: [1, 0, 0],
+        alpha: 0.5,
+        hex: '#ff0000',
+      })
+    ).toBe(false);
+    expect(isComposedColorToken('{color.brand}')).toBe(false);
+  });
+
+  test('cannot be written back through the Plugin API', () => {
+    expect(() =>
+      convertTokenValueToFigmaValue(
+        { components: '{color.brand}', alpha: 0.5 },
+        'color',
+        new Map()
+      )
+    ).toThrow(/separate opacity/);
+  });
+
+  test('COLOR_OPACITY is a valid scope', () => {
+    expect(isValidVariableScope('COLOR_OPACITY')).toBe(true);
+  });
+
+  test('COLOR_OPACITY tokens are typed as opacity', () => {
+    expect(
+      getTokenType({ $type: 'number', $value: 0.5, scopes: ['COLOR_OPACITY'] })
+    ).toBe('opacity');
   });
 });

--- a/src/common/transform/tokensToVariables.spec.ts
+++ b/src/common/transform/tokensToVariables.spec.ts
@@ -296,6 +296,21 @@ describe('getTokenType', () => {
     expect(getTokenType(token)).toBe('opacity');
   });
 
+  test('treats string easings marked with figmaType EASING as easings', () => {
+    const token = {
+      $type: 'string',
+      $value: 'ease-in',
+      $extensions: { figmaType: 'EASING' },
+    };
+    expect(getTokenType(token)).toBe('cubicBezier');
+    expect(mapTokenTypeToFigmaType(getTokenType(token))).toBe('EASING');
+    expect(
+      convertTokenValueToFigmaValue('gentle', 'cubicBezier', new Map())
+    ).toEqual({
+      type: 'GENTLE',
+    });
+  });
+
   test('detects opacity via figmaType FLOAT in strict DTCG export', () => {
     // Percentage opacity in strict DTCG: $type omitted, figmaType preserved
     const token = {

--- a/src/common/transform/tokensToVariables.ts
+++ b/src/common/transform/tokensToVariables.ts
@@ -10,6 +10,8 @@ interface ImportResult {
   variablesCreated: number;
   variablesUpdated: number;
   errors: string[];
+  /** Color aliases with a separate opacity this Figma version refused to write. */
+  composedColorsRejected: number;
 }
 
 /**
@@ -492,6 +494,62 @@ const extractTokens = (
   return tokens;
 };
 
+const isComposedFigmaValue = (value: any): value is ComposedColorValue =>
+  value?.type === 'VARIABLE_EXPRESSION' &&
+  value.expressionFunction === 'COMPOSE_COLOR';
+
+/**
+ * Some Figma clients can read color aliases with a separate opacity but
+ * reject writing them ("Composed color variable values are not supported").
+ */
+export const COMPOSED_COLOR_ISSUE_URL =
+  'https://github.com/figma/plugin-typings/issues/375';
+
+interface SetValueContext {
+  errors: string[];
+  /** Composed colors this Figma version refused to write. */
+  composedColorsRejected: number;
+}
+
+/**
+ * Sets a variable value. A composed color the runtime rejects is left
+ * untouched and counted, so the import result can point at the Figma issue
+ * instead of silently degrading the token.
+ */
+const setVariableValue = (
+  variable: Variable,
+  modeId: string,
+  figmaValue: VariableValue,
+  label: string,
+  context: SetValueContext
+) => {
+  const rejectComposed = (reason: string) => {
+    context.composedColorsRejected++;
+    context.errors.push(
+      `Skipped ${label}: this Figma version cannot write color aliases with a separate opacity (${reason}). See ${COMPOSED_COLOR_ISSUE_URL}`
+    );
+  };
+
+  try {
+    variable.setValueForMode(modeId, figmaValue);
+  } catch (error) {
+    if (isComposedFigmaValue(figmaValue)) {
+      rejectComposed(error.message);
+      return;
+    }
+    context.errors.push(`Failed to set value for ${label}: ${error.message}`);
+    return;
+  }
+
+  // Some clients drop the value without throwing: verify it actually stuck.
+  if (
+    isComposedFigmaValue(figmaValue) &&
+    !isComposedFigmaValue(variable.valuesByMode?.[modeId])
+  ) {
+    rejectComposed('the value was ignored by setValueForMode');
+  }
+};
+
 /**
  * Import design tokens and create Figma variables
  */
@@ -506,6 +564,7 @@ export const tokensToVariables = async (
     variablesCreated: 0,
     variablesUpdated: 0,
     errors: [],
+    composedColorsRejected: 0,
   };
 
   try {
@@ -759,13 +818,13 @@ export const tokensToVariables = async (
                   path: `${collectionName}/${path}`,
                 });
               } else {
-                try {
-                  variable.setValueForMode(defaultMode.modeId, figmaValue);
-                } catch (error) {
-                  result.errors.push(
-                    `Failed to set value for variable "${path}": ${error.message}`
-                  );
-                }
+                setVariableValue(
+                  variable,
+                  defaultMode.modeId,
+                  figmaValue,
+                  `variable "${path}"`,
+                  result
+                );
               }
 
               // Set values for other modes if they exist
@@ -793,13 +852,13 @@ export const tokensToVariables = async (
                       continue;
                     }
 
-                    try {
-                      variable.setValueForMode(mode.modeId, modeValue);
-                    } catch (error) {
-                      result.errors.push(
-                        `Failed to set value for mode "${modeName}" in variable "${path}": ${error.message}`
-                      );
-                    }
+                    setVariableValue(
+                      variable,
+                      mode.modeId,
+                      modeValue,
+                      `mode "${modeName}" in variable "${path}"`,
+                      result
+                    );
                   }
                 }
               }
@@ -832,7 +891,7 @@ export const tokensToVariables = async (
           );
           continue;
         }
-        variable.setValueForMode(modeId, figmaValue);
+        setVariableValue(variable, modeId, figmaValue, `"${path}"`, result);
       } catch (error) {
         result.errors.push(
           `Failed to resolve alias for "${path}": ${error.message}`
@@ -854,8 +913,15 @@ export const tokensToVariables = async (
 
     result.message = `Successfully imported tokens. ${parts.join(', ')}.`;
 
-    if (result.errors.length > 0) {
-      result.message += ` ${result.errors.length} error(s) occurred during import.`;
+    if (result.composedColorsRejected > 0) {
+      result.message += ` ${result.composedColorsRejected} value(s) skipped: this Figma version cannot write color aliases with a separate opacity yet.`;
+    }
+    const otherErrors = result.errors.length - result.composedColorsRejected;
+    if (otherErrors > 0) {
+      const firstOther = result.errors.find(
+        (error) => !error.startsWith('Skipped ')
+      );
+      result.message += ` ${otherErrors} error(s): ${firstOther} (see the plugin console for the full list)`;
     }
   } catch (error) {
     result.success = false;

--- a/src/common/transform/tokensToVariables.ts
+++ b/src/common/transform/tokensToVariables.ts
@@ -47,6 +47,10 @@ export const getTokenType = (token: any): string | null => {
   ) {
     return 'opacity';
   }
+  // Easing presets, springs and "hold" export as strings with a marker
+  if (token.$extensions?.figmaType === 'EASING') {
+    return 'cubicBezier';
+  }
   // DTCG format uses $type
   if (token.$type !== undefined) {
     return token.$type;
@@ -690,7 +694,12 @@ export const tokensToVariables = async (
                 variable.description = tokenDescription;
               }
 
-              if (tokenScopes) {
+              // Figma rejects scopes on TIMING and EASING variables
+              const acceptsScopes =
+                variable.resolvedType !== 'TIMING' &&
+                variable.resolvedType !== 'EASING';
+
+              if (tokenScopes && acceptsScopes) {
                 const invalidScopes = tokenScopes.filter(
                   (s) => !isValidVariableScope(s)
                 );

--- a/src/common/transform/tokensToVariables.ts
+++ b/src/common/transform/tokensToVariables.ts
@@ -1,4 +1,5 @@
 import { IResolver } from '@common/resolver';
+import { isOpacityScope } from './opacityScopes';
 import { parseDurationToSeconds, parseEasing } from './motion';
 
 interface ImportResult {
@@ -38,8 +39,7 @@ export const getTokenType = (token: any): string | null => {
   const scopes = getTokenScopes(token);
   const declaredType = token.$type ?? token.type;
   if (
-    scopes?.length === 1 &&
-    scopes[0] === 'OPACITY' &&
+    isOpacityScope(scopes) &&
     (declaredType === undefined ||
       declaredType === 'number' ||
       declaredType === 'string')
@@ -93,7 +93,9 @@ const getTokenDescription = (token: any): string => {
   return '';
 };
 
-const VALID_VARIABLE_SCOPES: ReadonlyArray<VariableScope> = [
+// `COLOR_OPACITY` (opacity of a color variable) is accepted by Figma at
+// runtime but missing from the published typings, hence the string array.
+const VALID_VARIABLE_SCOPES: ReadonlyArray<string> = [
   'ALL_SCOPES',
   'TEXT_CONTENT',
   'CORNER_RADIUS',
@@ -108,6 +110,7 @@ const VALID_VARIABLE_SCOPES: ReadonlyArray<VariableScope> = [
   'EFFECT_FLOAT',
   'EFFECT_COLOR',
   'OPACITY',
+  'COLOR_OPACITY',
   'FONT_FAMILY',
   'FONT_STYLE',
   'FONT_WEIGHT',
@@ -195,6 +198,21 @@ const rgbaToRgb = (
   };
 };
 
+const isReference = (value: any): boolean =>
+  typeof value === 'string' && value.startsWith('{') && value.endsWith('}');
+
+/**
+ * A color value exported from a Figma color alias with its own opacity:
+ * `{ components: "{color.brand}", alpha: 0.5 }` or a color object whose
+ * `alpha` / `a` is a reference. See "Color aliases with opacity" in README.
+ */
+export const isComposedColorToken = (value: any): boolean =>
+  typeof value === 'object' &&
+  value !== null &&
+  (isReference(value.components) ||
+    isReference(value.alpha) ||
+    isReference(value.a));
+
 /**
  * Converts token value to Figma variable value based on type
  */
@@ -240,6 +258,15 @@ export const convertTokenValueToFigmaValue = (
           return rgbaToRgb(value);
         }
       } else if (typeof value === 'object' && value !== null) {
+        if (isComposedColorToken(value)) {
+          // Exported from a color alias with its own opacity. Figma's Plugin
+          // API can read these but `setValueForMode` rejects them.
+          throw new Error(
+            `Color aliases with a separate opacity cannot be written through the Figma Plugin API yet: ${JSON.stringify(
+              value
+            )}`
+          );
+        }
         // DTCG 2025.10 color object: { colorSpace, components, alpha, hex }
         if ('colorSpace' in value) {
           // Prefer the hex fallback (always emitted by the plugin's DTCG export)

--- a/src/common/transform/tokensToVariables.ts
+++ b/src/common/transform/tokensToVariables.ts
@@ -1,4 +1,5 @@
 import { IResolver } from '@common/resolver';
+import { ComposedColorValue } from './color/composeColor';
 import { isOpacityScope } from './opacityScopes';
 import { parseDurationToSeconds, parseEasing } from './motion';
 
@@ -198,8 +199,47 @@ const rgbaToRgb = (
   };
 };
 
-const isReference = (value: any): boolean =>
+const isReference = (value: any): value is string =>
   typeof value === 'string' && value.startsWith('{') && value.endsWith('}');
+
+/**
+ * Turns a `{collection.group.name}` reference into the `collection/group/name`
+ * path used as key in the variable map.
+ */
+const referenceToFigmaPath = (reference: string): string =>
+  reference
+    .slice(1, -1)
+    // Remove .value / .$value suffix if present
+    .replace(/\.\$?value$/, '')
+    // Convert dots to slashes for Figma variable name format
+    .replace(/\./g, '/');
+
+const resolveReference = (
+  reference: string,
+  variableMap: Map<string, Variable>
+): VariableAlias | null => {
+  const referencedVariable = variableMap.get(referenceToFigmaPath(reference));
+  return referencedVariable
+    ? { type: 'VARIABLE_ALIAS', id: referencedVariable.id }
+    : null;
+};
+
+/**
+ * Converts an opacity token value (`0.5`, `"50%"`, `50`) to the 0..100
+ * percent number Figma stores.
+ */
+const toOpacityPercent = (value: any): number => {
+  if (typeof value === 'string' && value.trim().endsWith('%')) {
+    return parseFloat(value);
+  }
+  const numeric = typeof value === 'string' ? parseFloat(value) : value;
+  if (typeof numeric !== 'number' || Number.isNaN(numeric)) {
+    throw new Error(`Unsupported opacity value: ${JSON.stringify(value)}`);
+  }
+  // Fractions (0-1) are converted back to percent; values above 1 are
+  // assumed to already be percentages.
+  return numeric <= 1 ? numeric * 100 : numeric;
+};
 
 /**
  * A color value exported from a Figma color alias with its own opacity:
@@ -214,6 +254,68 @@ export const isComposedColorToken = (value: any): boolean =>
     isReference(value.a));
 
 /**
+ * A converted value that still holds a reference to a variable that does
+ * not exist yet (e.g. it lives in a collection imported later). Such values
+ * are set in a final pass once every variable has been created.
+ */
+export const hasUnresolvedReference = (value: any): boolean =>
+  isReference(value) || isComposedColorToken(value);
+
+/**
+ * Converts a composed color token back into the `COMPOSE_COLOR` expression
+ * Figma stores for a color alias with its own opacity. Returns `null` when a
+ * referenced variable cannot be found in the map (yet).
+ */
+export const convertComposedColorToFigmaValue = (
+  value: any,
+  variableMap: Map<string, Variable>
+): ComposedColorValue | null => {
+  const alphaValue = 'alpha' in value ? value.alpha : value.a;
+
+  let base: RGBA | VariableAlias;
+  if (isReference(value.components)) {
+    const alias = resolveReference(value.components, variableMap);
+    if (!alias) {
+      return null;
+    }
+    base = alias;
+  } else {
+    // The base color is a literal: rebuild it as a plain, opaque color value
+    // and reuse the regular color parsing.
+    let plain: any;
+    if (typeof value.components === 'string') {
+      plain = value.components;
+    } else if ('colorSpace' in value) {
+      plain = { ...value, alpha: 1 };
+    } else {
+      plain = { ...value, a: 1 };
+    }
+    const rgba = convertTokenValueToFigmaValue(plain, 'color', variableMap);
+    if (typeof rgba !== 'object' || rgba === null || !('r' in rgba)) {
+      throw new Error(`Unsupported color format: ${JSON.stringify(value)}`);
+    }
+    base = { r: rgba.r, g: rgba.g, b: rgba.b, a: 1 };
+  }
+
+  let opacity: number | VariableAlias;
+  if (isReference(alphaValue)) {
+    const alias = resolveReference(alphaValue, variableMap);
+    if (!alias) {
+      return null;
+    }
+    opacity = alias;
+  } else {
+    opacity = toOpacityPercent(alphaValue);
+  }
+
+  return {
+    type: 'VARIABLE_EXPRESSION',
+    expressionFunction: 'COMPOSE_COLOR',
+    expressionArguments: [base, opacity],
+  };
+};
+
+/**
  * Converts token value to Figma variable value based on type
  */
 export const convertTokenValueToFigmaValue = (
@@ -222,30 +324,13 @@ export const convertTokenValueToFigmaValue = (
   variableMap: Map<string, Variable>
 ): VariableValue => {
   // Handle alias references
-  if (
-    typeof value === 'string' &&
-    value.startsWith('{') &&
-    value.endsWith('}')
-  ) {
-    // Extract the alias path
-    const aliasPath = value.slice(1, -1);
-    // Remove .value / .$value suffix if present
-    const cleanPath = aliasPath.replace(/\.\$?value$/, '');
-    // Convert dots to slashes for Figma variable name format
-    const figmaPath = cleanPath.replace(/\./g, '/');
-
-    // Try to find the referenced variable
-    const referencedVariable = variableMap.get(figmaPath);
-    if (referencedVariable) {
-      return {
-        type: 'VARIABLE_ALIAS',
-        id: referencedVariable.id,
-      } as VariableAlias;
+  if (isReference(value)) {
+    const alias = resolveReference(value, variableMap);
+    if (alias) {
+      return alias;
     }
-
-    // If variable not found yet, store the reference for later resolution
-    console.warn(`Alias reference not resolved: ${cleanPath}`);
-    return value; // Will need second pass to resolve
+    // Variable not found yet: keep the reference for the final pass
+    return value;
   }
 
   // Handle actual values based on type
@@ -259,13 +344,11 @@ export const convertTokenValueToFigmaValue = (
         }
       } else if (typeof value === 'object' && value !== null) {
         if (isComposedColorToken(value)) {
-          // Exported from a color alias with its own opacity. Figma's Plugin
-          // API can read these but `setValueForMode` rejects them.
-          throw new Error(
-            `Color aliases with a separate opacity cannot be written through the Figma Plugin API yet: ${JSON.stringify(
-              value
-            )}`
-          );
+          // Exported from a color alias with its own opacity: written back
+          // as a COMPOSE_COLOR expression. Kept as-is until every referenced
+          // variable exists.
+          return (convertComposedColorToFigmaValue(value, variableMap) ??
+            value) as VariableValue;
         }
         // DTCG 2025.10 color object: { colorSpace, components, alpha, hex }
         if ('colorSpace' in value) {
@@ -300,20 +383,10 @@ export const convertTokenValueToFigmaValue = (
       }
       return value;
 
-    case 'opacity': {
+    case 'opacity':
       // Figma stores opacity as a 0-100 percent number.
       // Exports produce either "50%" (percentage setting) or 0.5 (fraction).
-      if (typeof value === 'string' && value.trim().endsWith('%')) {
-        return parseFloat(value);
-      }
-      const numeric = typeof value === 'string' ? parseFloat(value) : value;
-      if (typeof numeric !== 'number' || Number.isNaN(numeric)) {
-        throw new Error(`Unsupported opacity value: ${JSON.stringify(value)}`);
-      }
-      // Fractions (0-1) are converted back to percent; values above 1 are
-      // assumed to already be percentages.
-      return numeric <= 1 ? numeric * 100 : numeric;
-    }
+      return toOpacityPercent(value);
 
     case 'number':
     case 'dimension':
@@ -452,6 +525,16 @@ export const tokensToVariables = async (
     // Remove metadata if present
     const cleanedData = { ...tokensData };
     delete cleanedData.$extensions;
+
+    // Values referencing variables that do not exist yet (typically in a
+    // collection imported later). They are set once every variable exists.
+    const deferredValues: Array<{
+      variable: Variable;
+      modeId: string;
+      value: any;
+      type: string;
+      path: string;
+    }> = [];
 
     // Extract all collections from the tokens
     const collections: Map<string, any> = new Map();
@@ -613,12 +696,21 @@ export const tokensToVariables = async (
                 );
                 if (invalidScopes.length > 0) {
                   result.errors.push(
-                    `Token at path "${path}" has invalid scopes: ${invalidScopes.join(', ')}`
+                    `Token at path "${path}" has invalid scopes: ${invalidScopes.join(
+                      ', '
+                    )}`
                   );
                 }
                 const validScopes = tokenScopes.filter(isValidVariableScope);
                 if (validScopes.length > 0) {
-                  variable.scopes = validScopes;
+                  try {
+                    variable.scopes = validScopes;
+                  } catch (error) {
+                    // e.g. a runtime that does not know `COLOR_OPACITY` yet
+                    result.errors.push(
+                      `Failed to set scopes for variable "${path}": ${error.message}`
+                    );
+                  }
                 }
               }
             }
@@ -649,12 +741,22 @@ export const tokensToVariables = async (
                 variableMap
               );
 
-              try {
-                variable.setValueForMode(defaultMode.modeId, figmaValue);
-              } catch (error) {
-                result.errors.push(
-                  `Failed to set value for variable "${path}": ${error.message}`
-                );
+              if (hasUnresolvedReference(figmaValue)) {
+                deferredValues.push({
+                  variable,
+                  modeId: defaultMode.modeId,
+                  value: tokenValue,
+                  type: tokenType,
+                  path: `${collectionName}/${path}`,
+                });
+              } else {
+                try {
+                  variable.setValueForMode(defaultMode.modeId, figmaValue);
+                } catch (error) {
+                  result.errors.push(
+                    `Failed to set value for variable "${path}": ${error.message}`
+                  );
+                }
               }
 
               // Set values for other modes if they exist
@@ -670,6 +772,17 @@ export const tokensToVariables = async (
                       tokenType,
                       variableMap
                     );
+
+                    if (hasUnresolvedReference(modeValue)) {
+                      deferredValues.push({
+                        variable,
+                        modeId: mode.modeId,
+                        value: modes[modeName],
+                        type: tokenType,
+                        path: `${collectionName}/${path}`,
+                      });
+                      continue;
+                    }
 
                     try {
                       variable.setValueForMode(mode.modeId, modeValue);
@@ -695,58 +808,26 @@ export const tokensToVariables = async (
       }
     }
 
-    // Third pass: resolve any remaining alias references that were stored as strings
-    if (typeof figma !== 'undefined') {
-      for (const [fullPath, variable] of variableMap) {
-        try {
-          // Get the fresh collection reference
-          const collection =
-            await figma.variables.getVariableCollectionByIdAsync(
-              variable.variableCollectionId
-            );
-
-          if (!collection) continue;
-
-          // Check each mode for unresolved aliases
-          for (const mode of collection.modes) {
-            const currentValue = variable.valuesByMode[mode.modeId];
-
-            if (
-              typeof currentValue === 'string' &&
-              currentValue.startsWith('{') &&
-              currentValue.endsWith('}')
-            ) {
-              // This is an unresolved alias
-              const aliasPath = currentValue
-                .slice(1, -1)
-                .replace(/\.\$?value$/, '');
-              // Convert dots to slashes for Figma variable name format
-              const figmaPath = aliasPath.replace(/\./g, '/');
-              const referencedVariable = variableMap.get(figmaPath);
-
-              if (referencedVariable) {
-                const aliasValue: VariableAlias = {
-                  type: 'VARIABLE_ALIAS',
-                  id: referencedVariable.id,
-                };
-
-                try {
-                  variable.setValueForMode(mode.modeId, aliasValue);
-                } catch (error) {
-                  result.errors.push(
-                    `Failed to resolve alias for "${fullPath}": ${error.message}`
-                  );
-                }
-              } else {
-                result.errors.push(`Alias reference not found: ${aliasPath}`);
-              }
-            }
-          }
-        } catch (error) {
+    // Third pass: set the values whose references could not be resolved
+    // before, now that every variable from every collection exists.
+    for (const { variable, modeId, value, type, path } of deferredValues) {
+      try {
+        const figmaValue = convertTokenValueToFigmaValue(
+          value,
+          type,
+          variableMap
+        );
+        if (hasUnresolvedReference(figmaValue)) {
           result.errors.push(
-            `Error in second pass for "${fullPath}": ${error.message}`
+            `Alias reference not found for "${path}": ${JSON.stringify(value)}`
           );
+          continue;
         }
+        variable.setValueForMode(modeId, figmaValue);
+      } catch (error) {
+        result.errors.push(
+          `Failed to resolve alias for "${path}": ${error.message}`
+        );
       }
     }
 

--- a/src/common/transform/variablesToTokens.spec.ts
+++ b/src/common/transform/variablesToTokens.spec.ts
@@ -203,6 +203,7 @@ describe('variablesToTokens motion variables', () => {
     const preset = tokens['motion']['easing']['preset'];
     expect(preset.$type).toBe('string');
     expect(preset.$value).toBe('ease-in');
+    expect(preset.$extensions.figmaType).toBe('EASING');
 
     // Custom beziers carry real numbers and are unaffected by the setting
     const custom = tokens['motion']['easing']['custom'];
@@ -277,7 +278,7 @@ describe('variablesToTokens ordering', () => {
         description: '',
         codeSyntax: {},
         id,
-      }) as unknown as Variable;
+      } as unknown as Variable);
 
     // Variables arrive in a different order than defined in the collection
     const unorderedVariables = [

--- a/src/common/transform/variablesToTokens.ts
+++ b/src/common/transform/variablesToTokens.ts
@@ -31,7 +31,8 @@ const resolveAliasedValue = async (
   const collection = await resolver.getVariableCollectionById(
     target.variableCollectionId
   );
-  const modeId = collection?.defaultModeId ?? Object.keys(target.valuesByMode)[0];
+  const modeId =
+    collection?.defaultModeId ?? Object.keys(target.valuesByMode)[0];
 
   return resolveAliasedValue(target.valuesByMode[modeId], resolver, depth + 1);
 };
@@ -178,6 +179,10 @@ export const variablesToTokens = async (
       // add meta
       $extensions: {
         mode: filteredModesValues,
+        // Easings exported as names ("ease-in", "gentle", "hold") are plain
+        // strings; the marker lets the import recreate an EASING variable.
+        ...(variable.resolvedType === 'EASING' &&
+          tokenType === 'string' && { figmaType: 'EASING' }),
         ...(includeFigmaMetaData && {
           figma: {
             codeSyntax: variable.codeSyntax,


### PR DESCRIPTION
Closes #91

## Problem

Figma's "Control opacity at scale" release (September 3, 2026) lets a color variable alias another color and apply its own opacity on top, optionally driven by a number variable. The Plugin API returns these as an expression rather than an alias or RGBA (see figma/plugin-typings#375):

```js
{
  type: 'VARIABLE_EXPRESSION',
  expressionFunction: 'COMPOSE_COLOR',
  expressionArguments: [{ type: 'VARIABLE_ALIAS', id }, 50 /* or a FLOAT alias */],
}
```

The export fed that straight into the RGBA converter and crashed.

## Output format

Follows the shape proposed in #91: `components` holds the reference to the base color, `alpha` the opacity as a `0..1` number (or `"50%"` with the percentage opacity setting) or a reference to the driving number variable.

```json
"brand-translucent": { "$type": "color", "$value": { "components": "{color.brand}", "alpha": 0.5 } },
"brand-muted":       { "$type": "color", "$value": { "components": "{color.brand}", "alpha": "{opacity.50}" } }
```

- A literal base color gets the opacity baked into the regular color value for the chosen color mode; only an aliased opacity leaves a reference in `alpha` (or `a` for the object modes).
- Number variables with the new `COLOR_OPACITY` scope export like `OPACITY` ones.
- Import writes them back as `COMPOSE_COLOR` expressions (verified live: `setValueForMode` accepts them, the values persist and resolve with the expected alpha). References to collections imported later are deferred to a final pass instead of failing.
- Figma Desktop (126.9.6) still rejects these writes with "Composed color variable values are not supported" (figma/plugin-typings#375), while Figma's cloud plugin runtime accepts the identical call. When rejected, the value is left untouched, the import result counts the skipped values and the toast links to the issue. Import issues are now shown in the toast instead of only the console. Each composed write is also read back, so a client that drops the value without throwing is reported the same way.

## Changes

- New `composeColor.ts` converter and `opacityScopes.ts` helper; `normalizeValue` routes composed values through them.
- `COLOR_OPACITY` accepted as a valid scope on import; a runtime that rejects a scope no longer aborts the variable.
- Import: `convertComposedColorToFigmaValue` rebuilds the expression; unresolved references (plain or composed) are set in a final pass once every collection exists.
- Snapshot schema, example snapshot, README ("Color aliases with opacity") and skill doc updated.
- Tests for every base/opacity combination, the missing-alias fallback, scope handling, an end-to-end snapshot export, and the import flow against an in-memory Figma stub.

## Motion token import (bundled fix)

While verifying the import path against a live file, three motion issues came up and are fixed here too:

- Easings exported as strings (`"ease-in"` with expansion off, `"gentle"`, `"spring(bounce 0.35)"`, `"hold"`) imported as `STRING` variables. They now carry `$extensions.figmaType: "EASING"` and are recreated as `EASING` variables.
- Figma now attaches the curve to named bezier presets. The export prefers it, the preset table is corrected (`EASE_IN` 0.42/0/1/1, `EASE_OUT` 0/0/0.58/1, `EASE_IN_AND_OUT` 0.42/0/0.58/1), and the import matches curves back to presets with a small tolerance so older exports still round-trip.
- Figma rejects `scopes` on `TIMING` and `EASING` variables, which aborted the import of every motion variable exported with "Include scopes" on. Scopes are now skipped for those types.

Version bumped to 3.12.0 since 3.11.0 is already published on the community.

## Notes

- `@figma/plugin-typings` 1.138.0 has no typings for this yet, so the shape is defined locally.
- The REST API shape for these variables is undocumented; if it differs from the Plugin API, only the REST resolver needs a mapping.
